### PR TITLE
docs(workflow): add ChatGPT, Codex, and GitHub operating pattern

### DIFF
--- a/docs/assistant-brief.md
+++ b/docs/assistant-brief.md
@@ -5,6 +5,7 @@
 - Smallest safe change: Prefer incremental, reversible edits.
 - Small batches: Prefer one meaningful chunk at a time, then summarize what changed and what remains next.
 - Recovery before rush: If a session or approval flow freezes, inspect current state first and resume from the last stable point.
+- Shared external spine: Anchor important state in GitHub through repo files, issues, PRs, Atlas, or ADRs rather than relying on tool memory alone.
 - Hospitality: clear messages, zero shaming, Brave-friendly UIs.
 - Guarded patches only: never overwrite/rename widely without a backup or branch.
 
@@ -29,3 +30,4 @@
 3) Fix one red/yellow or one integration slice, then summarize touched files + next step
 4) Update status.json if state changed
 5) Regenerate Atlas
+6) Anchor any real decision in GitHub-visible memory before treating it as settled

--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -174,11 +174,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>15</strong>
+          <strong>16</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>15</strong>
+          <strong>16</strong>
         </div>
       </div>
     </section>
@@ -227,6 +227,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/decisions/0002-groundmesh-world-relationship.md</code></td>
   <td>Keeps GroundMesh as the canonical core repo, keeps groundmesh-world as the narrative public seed, and merges by small translation steps rather than repo collapse.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0003-chatgpt-codex-github-operating-pattern.md">ADR-0003</a></td>
+  <td><strong>ChatGPT, Codex, and GitHub Operating Pattern</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0003-chatgpt-codex-github-operating-pattern.md</code></td>
+  <td>Establishes GitHub as the shared external spine between ChatGPT, Codex, and GroundMesh work so important state is anchored in visible project memory.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../assistant-brief.md">DOC-ASSISTANT-BRIEF</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -17,6 +17,14 @@
       "summary": "Keeps GroundMesh as the canonical core repo, keeps groundmesh-world as the narrative public seed, and merges by small translation steps rather than repo collapse."
     },
     {
+      "id": "ADR-0003",
+      "name": "ChatGPT, Codex, and GitHub Operating Pattern",
+      "type": "decision",
+      "status": "active",
+      "path": "docs/decisions/0003-chatgpt-codex-github-operating-pattern.md",
+      "summary": "Establishes GitHub as the shared external spine between ChatGPT, Codex, and GroundMesh work so important state is anchored in visible project memory."
+    },
+    {
       "id": "DOC-ASSISTANT-BRIEF",
       "name": "Assistant Brief",
       "type": "guide",

--- a/docs/decisions/0003-chatgpt-codex-github-operating-pattern.md
+++ b/docs/decisions/0003-chatgpt-codex-github-operating-pattern.md
@@ -1,0 +1,81 @@
+# 0003 — ChatGPT, Codex, and GitHub Operating Pattern
+Date: 2026-04-13T20:05:00Z
+Status: Accepted
+
+## Context
+GroundMesh now operates across multiple active surfaces:
+
+- ChatGPT for strategy, review, continuity, and interpretation
+- Codex for concentrated implementation and repo-local execution
+- GitHub for versioned public memory, merge control, and inspectable work history
+
+Those tools are useful together, but they do not automatically share one internal memory across tabs,
+products, or sessions. That makes hidden or implied continuity fragile.
+
+GroundMesh also needs a working rule that reduces confusion when many conversations, patches, PRs,
+and ideas are alive at once.
+
+## Decision
+Use GitHub as the shared external spine between tools.
+
+The working pattern is:
+
+1. ChatGPT is used for:
+   - strategy
+   - architecture
+   - review
+   - issue shaping
+   - continuity keeping
+2. Codex is used for:
+   - concrete repo edits
+   - implementation batches
+   - debugging
+   - patch generation
+   - local verification
+3. GitHub is used for:
+   - canonical source of truth
+   - issue and PR memory
+   - merge gate
+   - execution ledger visible to humans and systems
+
+The core rule is:
+
+> Nothing important exists until it is anchored in GitHub.
+
+That anchor may be:
+
+- a repo file
+- an issue
+- a pull request
+- an ADR
+- an Atlas entry
+- a comment that records a real decision or state change
+
+## Operating guidance
+
+When speed matters:
+
+- let Codex work in a branch-sized batch
+- let ChatGPT inspect the diff, PR, or repo state
+- merge only what fits Atlas, Tranquility Protocol, and current GroundMesh reality
+
+When clarity matters:
+
+- ask ChatGPT to reduce repo state, PRs, and issues into the next smallest useful step
+
+When continuity matters:
+
+- record decisions in repo docs, ADRs, Atlas, issues, PR bodies, or comments
+- do not rely on tool memory alone
+
+When many things are in motion:
+
+- prefer smaller safe batches over large hidden sweeps
+- summarize touched files and the next step after each meaningful chunk
+
+## Consequences
+
+- GroundMesh gains a stable cross-tool memory pattern instead of depending on hidden state.
+- Work becomes easier to review, recover, and continue after pauses or platform friction.
+- ChatGPT, Codex, and GitHub become complementary rather than redundant.
+- Stewardship stays human-led while implementation can scale through clearer delegation.


### PR DESCRIPTION
## Why
- anchor the cross-tool operating model in visible project memory
- reduce confusion across ChatGPT, Codex, GitHub, and future sessions
- make the shared-memory rule part of GroundMesh doctrine instead of leaving it only in chat

## What changed
- add ADR 0003 for the ChatGPT, Codex, and GitHub operating pattern
- update the assistant brief with the shared external spine rule
- register the new decision in Atlas and regenerate the Atlas page

## Core rule
> Nothing important exists until it is anchored in GitHub.

That anchor may be a repo file, issue, PR, ADR, Atlas entry, or a real state-bearing comment.
