### PR TITLE
docs(workflow): add less-but-anchored stewardship rule

### DIFF
--- a/docs/assistant-brief.md
+++ b/docs/assistant-brief.md
@@ -6,6 +6,7 @@
 - Small batches: Prefer one meaningful chunk at a time, then summarize what changed and what remains next.
 - Recovery before rush: If a session or approval flow freezes, inspect current state first and resume from the last stable point.
 - Shared external spine: Anchor important state in GitHub through repo files, issues, PRs, Atlas, or ADRs rather than relying on tool memory alone.
+- Less, but more anchored: Do not add a new layer unless it clearly reduces friction, increases clarity, improves execution, or preserves meaning in a more usable form.
 - Hospitality: clear messages, zero shaming, Brave-friendly UIs.
 - Guarded patches only: never overwrite/rename widely without a backup or branch.
 

--- a/docs/decisions/0003-chatgpt-codex-github-operating-pattern.md
+++ b/docs/decisions/0003-chatgpt-codex-github-operating-pattern.md
@@ -73,9 +73,16 @@ When many things are in motion:
 - prefer smaller safe batches over large hidden sweeps
 - summarize touched files and the next step after each meaningful chunk
 
+When deciding whether to add another layer:
+
+- do not add a new layer unless it clearly reduces friction, increases clarity, improves execution, or preserves meaning in a more usable form
+- treat productive-looking overflow as a risk, not as proof of progress
+- prefer less, but more anchored
+
 ## Consequences
 
 - GroundMesh gains a stable cross-tool memory pattern instead of depending on hidden state.
 - Work becomes easier to review, recover, and continue after pauses or platform friction.
 - ChatGPT, Codex, and GitHub become complementary rather than redundant.
 - Stewardship stays human-led while implementation can scale through clearer delegation.
+- Abundance is guided toward buildable reality instead of drifting into fog.


### PR DESCRIPTION
## Why
- anchor the new stewardship safeguard in visible project memory
- reduce the risk of productive-looking overflow, fog, and unnecessary extra layers
- keep the operating doctrine aligned with the simpler, gentler, more effective way of working we just clarified

## What changed
- add the "less, but more anchored" rule to the assistant brief
- extend ADR 0003 with a simple filter for when to add another layer

## Principle
Do not add a new layer unless it clearly reduces friction, increases clarity, improves execution, or preserves meaning in a more usable form.
