### PR TITLE
docs(status): reflect Pages transition and trigger fresh deploy

### DIFF
--- a/.github/workflows/json-and-pages-check.yml
+++ b/.github/workflows/json-and-pages-check.yml
@@ -19,9 +19,15 @@ jobs:
       - name: Report pages existence (best-effort)
         run: |
           set +e
-          BASE="https://'"$GITHUB_REPOSITORY_OWNER"'.github.io/'"$(basename "$GITHUB_REPOSITORY")"
+          BASE="https://${GITHUB_REPOSITORY_OWNER}.github.io/$(basename "$GITHUB_REPOSITORY")"
+          bad=0
           for u in "$BASE/" "$BASE/contribute.html" "$BASE/get-started/index.html" "$BASE/map.html" "$BASE/contact.html" "$BASE/privacy.html" "$BASE/landscape.html" "$BASE/atlas/index.html" "$BASE/compute.html"; do
             echo "HEAD $u"
-            code=$(curl -s -o /dev/null -w "%{http_code}" -I "$u")
+            code=$(curl -s -o /dev/null -w "%{http_code}" -I "$u" || echo "curl-error")
             echo " -> $code"
+            if [ "$code" != "200" ]; then
+              bad=$((bad+1))
+            fi
           done
+          echo "Non-200 pages reported: $bad"
+          exit 0

--- a/docs/data/status.json
+++ b/docs/data/status.json
@@ -1,41 +1,45 @@
 {
-  "updated_utc": "2026-04-13T07:05:00Z",
+  "updated_utc": "2026-04-13T19:35:00Z",
   "components": {
+    "deployment_source": {
+      "status": "yellow",
+      "note": "GitHub Pages source was switched toward GitHub Actions; awaiting a clean docs-based deploy to replace the stale branch-root site"
+    },
     "home_page": {
       "status": "yellow",
-      "note": "Unified front door revision is ready locally; live publish still pending"
+      "note": "Root URL still resolves, but current live content is a stale branch-root Jekyll page rather than the intended docs front door"
     },
     "contributors_page": {
-      "status": "green",
-      "note": "Visible and loads"
+      "status": "yellow",
+      "note": "Expected docs route, but currently 404 on the public site while deployment source transition completes"
     },
     "get_started_page": {
       "status": "yellow",
-      "note": "Builder-facing HTML page is ready locally; live publish still pending"
+      "note": "Builder-facing HTML page is present in the repo but still 404 publicly until the docs-based Pages deploy takes over"
     },
     "map_page": {
-      "status": "green",
-      "note": "Embed and add-pin paths are present, with cleaned public CTA markup"
+      "status": "yellow",
+      "note": "Map page is correct in docs, but the public route is still 404 under the current stale Pages output"
     },
     "contact_page": {
       "status": "yellow",
-      "note": "Simple public human contact path is present locally; live publish still pending"
+      "note": "Simple public human contact path exists in docs, but the live route is still 404"
     },
     "privacy_page": {
       "status": "yellow",
-      "note": "Plain-language privacy posture is present locally; live publish still pending"
+      "note": "Plain-language privacy posture exists in docs, but the live route is still 404"
     },
     "landscape_page": {
       "status": "yellow",
-      "note": "Broad scan page is ready locally; live publish still pending"
+      "note": "Broad scan page exists in docs, but the live route is still 404"
     },
     "compute_page": {
-      "status": "green",
-      "note": "Page and metrics stub live"
+      "status": "yellow",
+      "note": "Compute page exists in docs, but the live route is still 404 under the stale publish source"
     },
     "atlas_page": {
-      "status": "green",
-      "note": "Page published and loads"
+      "status": "yellow",
+      "note": "Atlas is correct in docs, but the public route is still 404 under the stale publish source"
     }
   }
 }

--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -122,18 +122,18 @@
       </div>
     </section>
 
-    <h2>Confirmed live pages</h2>
+    <h2>Live deployment transition</h2>
     <section class="grid">
       <article class="card">
-        <div class="status ok">Live now</div>
-        <h3>GroundMesh docs site</h3>
-        <p>The original public/docs surface is live and reachable.</p>
+        <div class="status warn">Transition</div>
+        <h3>GroundMesh root URL</h3>
+        <p>The root URL still resolves, but is currently serving a stale branch-root Jekyll page rather than the intended docs front door.</p>
         <a href="https://mailgmirko-creator.github.io/groundmesh/">Open live site</a>
       </article>
       <article class="card">
-        <div class="status ok">Live now</div>
-        <h3>GroundMesh Atlas</h3>
-        <p>The Atlas page on GitHub Pages responds successfully.</p>
+        <div class="status warn">Transition</div>
+        <h3>Docs routes</h3>
+        <p>The docs routes are present in the repo, but are still returning 404 publicly while GitHub Pages changes over to the docs-based Actions deploy.</p>
         <a href="https://mailgmirko-creator.github.io/groundmesh/atlas/index.html">Open live Atlas</a>
       </article>
       <article class="card">


### PR DESCRIPTION
## Why
- update the project's own public status memory to match the current live reality
- stop claiming success for docs routes that are still 404 publicly
- provide a small fresh `main` push after the GitHub Pages source switch to GitHub Actions

## What changed
- update `docs/data/status.json` to reflect the live Pages transition accurately
- update `docs/landscape.html` so it describes the current deployment transition instead of stale live success

## Expected effect
Once this reaches `main`, it should give the explicit Pages workflow a fresh docs-triggering push and help the live site move from the stale branch-root page to the intended docs deployment.
