### PR TITLE
docs(status): mark public site live

### DIFF
--- a/docs/data/status.json
+++ b/docs/data/status.json
@@ -1,45 +1,45 @@
 {
-  "updated_utc": "2026-04-13T19:35:00Z",
+  "updated_utc": "2026-04-14T08:20:00Z",
   "components": {
     "deployment_source": {
-      "status": "yellow",
-      "note": "GitHub Pages source was switched toward GitHub Actions; awaiting a clean docs-based deploy to replace the stale branch-root site"
+      "status": "green",
+      "note": "GitHub Pages is now serving the docs-based site successfully through the GitHub Actions deployment path"
     },
     "home_page": {
-      "status": "yellow",
-      "note": "Root URL still resolves, but current live content is a stale branch-root Jekyll page rather than the intended docs front door"
+      "status": "green",
+      "note": "Unified docs front door is live at the public root URL"
     },
     "contributors_page": {
-      "status": "yellow",
-      "note": "Expected docs route, but currently 404 on the public site while deployment source transition completes"
+      "status": "green",
+      "note": "Contributors route loads publicly"
     },
     "get_started_page": {
-      "status": "yellow",
-      "note": "Builder-facing HTML page is present in the repo but still 404 publicly until the docs-based Pages deploy takes over"
+      "status": "green",
+      "note": "Builder-facing HTML page loads publicly"
     },
     "map_page": {
-      "status": "yellow",
-      "note": "Map page is correct in docs, but the public route is still 404 under the current stale Pages output"
+      "status": "green",
+      "note": "Map page and add-pin paths load publicly"
     },
     "contact_page": {
-      "status": "yellow",
-      "note": "Simple public human contact path exists in docs, but the live route is still 404"
+      "status": "green",
+      "note": "Simple public human contact path loads publicly"
     },
     "privacy_page": {
-      "status": "yellow",
-      "note": "Plain-language privacy posture exists in docs, but the live route is still 404"
+      "status": "green",
+      "note": "Plain-language privacy posture loads publicly"
     },
     "landscape_page": {
-      "status": "yellow",
-      "note": "Broad scan page exists in docs, but the live route is still 404"
+      "status": "green",
+      "note": "Broad scan page loads publicly"
     },
     "compute_page": {
-      "status": "yellow",
-      "note": "Compute page exists in docs, but the live route is still 404 under the stale publish source"
+      "status": "green",
+      "note": "Compute page and metrics stub load publicly"
     },
     "atlas_page": {
-      "status": "yellow",
-      "note": "Atlas is correct in docs, but the public route is still 404 under the stale publish source"
+      "status": "green",
+      "note": "Atlas route loads publicly"
     }
   }
 }

--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -110,7 +110,7 @@
       <div class="eyebrow">GroundMesh Landscape</div>
       <h1>What exists here, on the web, and around the project right now.</h1>
       <p>
-        This page is a broad scan of the GroundMesh ecosystem as checked on April 13, 2026.
+        This page is a broad scan of the GroundMesh ecosystem as checked on April 14, 2026.
         It separates the public-facing surfaces, local repos, and adjacent operational experiments
         so we can grow from what is already real instead of duplicating it blindly.
       </p>
@@ -122,18 +122,18 @@
       </div>
     </section>
 
-    <h2>Live deployment transition</h2>
+    <h2>Confirmed live pages</h2>
     <section class="grid">
       <article class="card">
-        <div class="status warn">Transition</div>
-        <h3>GroundMesh root URL</h3>
-        <p>The root URL still resolves, but is currently serving a stale branch-root Jekyll page rather than the intended docs front door.</p>
+        <div class="status ok">Live now</div>
+        <h3>GroundMesh docs site</h3>
+        <p>The unified docs front door is now live and reachable at the public root URL.</p>
         <a href="https://mailgmirko-creator.github.io/groundmesh/">Open live site</a>
       </article>
       <article class="card">
-        <div class="status warn">Transition</div>
-        <h3>Docs routes</h3>
-        <p>The docs routes are present in the repo, but are still returning 404 publicly while GitHub Pages changes over to the docs-based Actions deploy.</p>
+        <div class="status ok">Live now</div>
+        <h3>GroundMesh Atlas</h3>
+        <p>The Atlas route now responds successfully along with the wider docs surface.</p>
         <a href="https://mailgmirko-creator.github.io/groundmesh/atlas/index.html">Open live Atlas</a>
       </article>
       <article class="card">


### PR DESCRIPTION
## Why
- the public site is now live across the full docs surface
- the repo's own status snapshot and landscape page still describe yesterday's deployment transition
- GroundMesh memory should match reality now that all tracked public routes respond successfully

## What changed
- update `docs/data/status.json` to mark the deployment source and public routes green
- update `docs/landscape.html` so the live section describes the current successful public state

## Verification
- `scripts/health-check.ps1` now reports `Live OK: 10  Live BAD: 0`
- all tracked local files remain present
