### PR TITLE
docs(index): surface get started on front door

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -143,7 +143,7 @@
       padding: 20px;
     }
     .metric strong { display: block; font-size: 1.5rem; margin-bottom: 8px; }
-    .surface-grid { grid-template-columns: repeat(5, minmax(0, 1fr)); margin-bottom: 18px; }
+    .surface-grid { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin-bottom: 18px; }
     .cards { grid-template-columns: repeat(3, 1fr); }
     .two { grid-template-columns: 1fr 1fr; margin-top: 18px; }
     .card, .box { padding: 24px; }
@@ -195,6 +195,7 @@
         <a class="nav-link" href="#join">Join</a>
         <a class="nav-link" href="#support">Support</a>
         <a class="nav-link" href="#trust">Trust</a>
+        <a class="nav-link" href="get-started/index.html">Get Started</a>
         <a class="nav-link" href="atlas/index.html">Atlas</a>
         <a class="nav-link" href="contribute.html">Contribute</a>
         <a class="nav-link" href="map.html">Map</a>
@@ -222,7 +223,8 @@
           that keeps growth inspectable and less likely to drift.
         </p>
         <div class="actions">
-          <a class="btn primary" href="#join">Stand for Life</a>
+          <a class="btn primary" href="get-started/index.html">Get Started</a>
+          <a class="btn secondary" href="#join">Stand for Life</a>
           <a class="btn secondary" href="#covenant">Read the Covenant</a>
           <a class="btn secondary" href="atlas/index.html">Open Atlas</a>
           <a class="btn secondary" href="https://mailgmirko-creator.github.io/groundmesh-world/">Open World Seed</a>
@@ -238,6 +240,7 @@
     </section>
 
     <section class="surface-grid">
+      <article class="card"><h3>Get Started</h3><p>The clearest first stop for builders who want the repo, checks, and safe contribution path.</p><a href="get-started/index.html">Open Get Started</a></article>
       <article class="card"><h3>Atlas</h3><p>See what already exists before adding anything new.</p><a href="atlas/index.html">Open Atlas</a></article>
       <article class="card"><h3>Contribute</h3><p>The low-friction public on-ramp for people who want to help.</p><a href="contribute.html">Open Contributors Hub</a></article>
       <article class="card"><h3>Map</h3><p>The public orientation layer for visible relation and participation.</p><a href="map.html">Open the Map</a></article>
@@ -294,7 +297,8 @@
       </div>
       <div class="box">
         <h3>Current best path</h3>
-        <p>Use the existing contributors flow while the safer live intake layer is still being built.</p>
+        <p>Use <code>Get Started</code> if you want to help build the project itself, or the contributors flow if you want the lighter public entry path.</p>
+        <a href="get-started/index.html">Open Get Started</a><br />
         <a href="contribute.html">Go to Contributors</a>
       </div>
     </section>


### PR DESCRIPTION
## Why
- `Get Started` already exists, but it is still too easy to miss from the public front door
- first-time builders should have a direct path into the repo, checks, and safe contribution flow
- this is a small usability improvement that keeps the site honest without adding another layer

## What changed
- add `Get Started` to the front-door navigation
- make `Get Started` the primary first-screen builder action
- add a `Get Started` card to the main public surface grid
- clarify the participation section so builders can choose `Get Started` while lighter public entrants can use `Contribute`

## Verification
- `scripts/health-check.ps1` still reports `Live OK: 10  Live BAD: 0`
- `scripts/health-check.ps1` still reports `Files OK: 13  Files MISS: 0`
