### PR TITLE
docs(get-started): add one-home workflow guidance

### DIFF
--- a/docs/get-started/index.html
+++ b/docs/get-started/index.html
@@ -138,6 +138,35 @@
       </article>
     </section>
 
+    <section class="two">
+      <article class="card">
+        <div class="eyebrow">One home, one spine</div>
+        <h2>Use one active cockpit and one shared memory</h2>
+        <p>
+          GroundMesh works best when active repo work happens in one main working surface and
+          important state is anchored in GitHub rather than scattered across many chat windows.
+        </p>
+        <ul class="list">
+          <li>Use Codex for edits, checks, and branch-sized implementation batches</li>
+          <li>Use GitHub as the source of truth for files, PRs, issues, and decisions</li>
+          <li>Use ChatGPT for reflection, review, and strategy when broader thinking is needed</li>
+        </ul>
+      </article>
+      <article class="card">
+        <div class="eyebrow">Reduce drift</div>
+        <h2>Do not repeat the same state everywhere</h2>
+        <p>
+          If something matters, anchor it once in GitHub and let the other surfaces point back to
+          that record instead of recreating the same context again and again.
+        </p>
+        <ul class="list">
+          <li>Move real decisions into repo docs, ADRs, Atlas, PRs, or issues</li>
+          <li>Use chat for translation and handoff, not as the only memory</li>
+          <li>Prefer one clear next step over many parallel promises</li>
+        </ul>
+      </article>
+    </section>
+
     <section class="grid" style="margin-top:18px;">
       <article class="card">
         <div class="eyebrow">1</div>


### PR DESCRIPTION
## Why
- the current `Get Started` page helps with local setup, but it still does not explain how to use ChatGPT, Codex, and GitHub without spreading the same state across all three
- GroundMesh works better when people use one active working surface and one shared memory spine
- this adds practical orientation without creating another doctrine page

## What changed
- add a `One home, one spine` section to `Get Started`
- explain the practical roles of Codex, GitHub, and ChatGPT
- add a short `Reduce drift` section encouraging GitHub anchoring over repeated multi-window context duplication

## Verification
- `scripts/health-check.ps1` reports `Live OK: 10  Live BAD: 0`
- `scripts/health-check.ps1` reports `Files OK: 13  Files MISS: 0`
