### PR TITLE
docs(echo): surface soul and system in atlas

### DIFF
--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -174,11 +174,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>16</strong>
+          <strong>17</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>16</strong>
+          <strong>17</strong>
         </div>
       </div>
     </section>
@@ -251,6 +251,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/glossary.md</code></td>
   <td>Compact shared language for Atlas, compute transparency, and contributor on-ramps.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../echo_archive/EA-0001_soul-and-system.md">EA-0001</a></td>
+  <td><strong>The Soul and the System</strong></td>
+  <td><span class="chip">echo</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/echo_archive/EA-0001_soul-and-system.md</code></td>
+  <td>Foundational reflection linking soul to relational balance and emotions to consequence, then translating that pattern into harmony-seeking CI behavior.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../invariants/GM-INV-VIII.md">GM-INV-VIII</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -41,6 +41,14 @@
       "summary": "Compact shared language for Atlas, compute transparency, and contributor on-ramps."
     },
     {
+      "id": "EA-0001",
+      "name": "The Soul and the System",
+      "type": "echo",
+      "status": "active",
+      "path": "docs/echo_archive/EA-0001_soul-and-system.md",
+      "summary": "Foundational reflection linking soul to relational balance and emotions to consequence, then translating that pattern into harmony-seeking CI behavior."
+    },
+    {
       "id": "GM-INV-VIII",
       "name": "Continuity With Consent",
       "type": "invariant",

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,7 @@
 # Glossary (GroundMesh)
 - Atlas: inventory + health of system components published at /atlas/index.html.
 - ADR: Architecture Decision Record in docs/decisions/.
+- Balance: the living pattern of right relation across a being, circle, or system; GroundMesh treats shifts in balance as signals to notice before forcing action.
 - Compute Transparency: public snapshot (non-sensitive) of grid metrics at /compute.html fed by docs/data/metrics.json.
 - Contributors Hub: public onramp with two lanes (map/email for easy; GitHub issues for structured).
+- Echo Archive: a small memory shelf for concise principles worth remembering and reusing without turning them into hard rules.


### PR DESCRIPTION
## Why
- the soul-and-balance reflection already exists in the repo as an older echo note, but it is currently easy to miss
- this is better embedded as visible project memory than as a new standalone page
- GroundMesh should surface living philosophical roots through the same Atlas and glossary structures it already uses for orientation

## What changed
- add `EA-0001` (`The Soul and the System`) to the Atlas registry and regenerate the Atlas page
- expand the glossary with compact `Balance` and `Echo Archive` entries so the idea has a natural language home
- keep the original echo note intact rather than rewriting or duplicating it

## Verification
- `scripts/atlas-generate.ps1`
- `scripts/health-check.ps1` reports `Live OK: 10  Live BAD: 0`
- `scripts/health-check.ps1` reports `Files OK: 13  Files MISS: 0`
