### PR TITLE
meta(github): tighten issue and pr guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Something isn’t working as expected
+title: "[Bug]: "
 labels: [bug]
 body:
   - type: textarea
@@ -10,11 +11,25 @@ body:
       placeholder: Clear steps + expected vs. actual
     validations:
       required: true
+  - type: input
+    id: where
+    attributes:
+      label: Where did this happen?
+      description: Page URL, file path, script name, or workflow run.
+      placeholder: https://..., docs/index.html, scripts/health-check.ps1, GitHub Action run
+    validations:
+      required: true
   - type: textarea
     id: steps
     attributes:
       label: Steps to reproduce
       placeholder: 1) … 2) … 3) …
+  - type: textarea
+    id: smallest_fix
+    attributes:
+      label: Smallest fix you expect
+      description: What would count as the first honest repair?
+      placeholder: One route fixed, one message clarified, one script step corrected.
   - type: input
     id: env
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Quick Question
-    url: https://github.com
-    about: Short questions or clarifications.
+  - name: GroundMesh Contribute
+    url: https://mailgmirko-creator.github.io/groundmesh/contribute.html
+    about: Start here for contribution paths, quick forms, and GitHub entry points.
+  - name: GroundMesh Contact
+    url: https://mailgmirko-creator.github.io/groundmesh/contact.html
+    about: Use this for first contact, corrections, removals, or questions that do not need an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,6 +19,22 @@ body:
     validations:
       required: true
   - type: textarea
+    id: existing_state
+    attributes:
+      label: What already exists?
+      description: Note any current page, script, issue, or Atlas entry related to this.
+      placeholder: Existing page/path, current behavior, or Atlas item already connected to this idea.
+    validations:
+      required: true
+  - type: textarea
+    id: smallest_slice
+    attributes:
+      label: Smallest useful first slice
+      description: What is the smallest safe version of this idea worth doing first?
+      placeholder: One page, one workflow step, one field, one visible improvement.
+    validations:
+      required: true
+  - type: textarea
     id: inputs
     attributes:
       label: Inputs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,23 @@
-## Summary
-What does this change do and why?
+## Why
+Why does this change matter right now?
+
+## What Changed
+What did you actually change in this batch?
+
+## Verification
+- [ ] I can perform the main action and see the expected result
+- [ ] I ran the relevant local check or explained why I could not
+- [ ] Clear error messages for invalid input (if applicable)
+- [ ] Works in Brave with shields up (if UI)
+- [ ] Docs or Atlas updated if public/project state changed
+
+## Scope Guard
+- [ ] This PR stays focused on one main purpose
+- [ ] I checked what already existed before adding new structure
+- [ ] Non-goals are clear or this change is small enough not to need them
 
 ## Linked Issue
 Closes #<issue-number>
 
-## Acceptance Checklist
-- [ ] I can perform the main action and see the expected result
-- [ ] Clear error messages for invalid input
-- [ ] Works in Brave with shields up (if UI)
-- [ ] Docs updated (if needed)
-
-## Screenshots / Notes
+## Non-Goals / Notes
+What this PR does not do, or anything reviewers should know.


### PR DESCRIPTION
## Why
- GroundMesh already has issue and PR templates, but they still leave too much room for drift or generic GitHub behavior
- if more people arrive, GitHub should steer them toward one small, honest, anchored change rather than wide vague motion
- the current contact link also still points to generic `github.com` instead of GroundMesh itself

## What changed
- tighten the PR template around `Why`, `What Changed`, verification, and scope guardrails
- improve the feature request template with `What already exists?` and `Smallest useful first slice`
- improve the bug report template with `Where did this happen?` and `Smallest fix you expect`
- replace the generic contact link with GroundMesh `Contribute` and `Contact` links

## Verification
- reviewed the rendered template text for simplicity and scope discipline
- no runtime or site behavior changed in this batch
