### PR TITLE
docs(decision): define active and dev promotion model

### DIFF
--- a/docs/assistant-brief.md
+++ b/docs/assistant-brief.md
@@ -7,6 +7,7 @@
 - Recovery before rush: If a session or approval flow freezes, inspect current state first and resume from the last stable point.
 - Shared external spine: Anchor important state in GitHub through repo files, issues, PRs, Atlas, or ADRs rather than relying on tool memory alone.
 - Less, but more anchored: Do not add a new layer unless it clearly reduces friction, increases clarity, improves execution, or preserves meaning in a more usable form.
+- Promotion model: `main` is the active public lane, `dev` is the staging lane when needed, and short-lived branches carry focused work.
 - Hospitality: clear messages, zero shaming, Brave-friendly UIs.
 - Guarded patches only: never overwrite/rename widely without a backup or branch.
 

--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -174,11 +174,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>17</strong>
+          <strong>18</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>17</strong>
+          <strong>18</strong>
         </div>
       </div>
     </section>
@@ -235,6 +235,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/decisions/0003-chatgpt-codex-github-operating-pattern.md</code></td>
   <td>Establishes GitHub as the shared external spine between ChatGPT, Codex, and GroundMesh work so important state is anchored in visible project memory.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0004-active-dev-promotion-model.md">ADR-0004</a></td>
+  <td><strong>Active / Dev Promotion Model</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0004-active-dev-promotion-model.md</code></td>
+  <td>Keeps the ACTIVE / DEV instinct, but translates it into one canonical repo with main as the public lane, dev as staging when needed, and separate sensitive services only where risk truly differs.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../assistant-brief.md">DOC-ASSISTANT-BRIEF</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -25,6 +25,14 @@
       "summary": "Establishes GitHub as the shared external spine between ChatGPT, Codex, and GroundMesh work so important state is anchored in visible project memory."
     },
     {
+      "id": "ADR-0004",
+      "name": "Active / Dev Promotion Model",
+      "type": "decision",
+      "status": "active",
+      "path": "docs/decisions/0004-active-dev-promotion-model.md",
+      "summary": "Keeps the ACTIVE / DEV instinct, but translates it into one canonical repo with main as the public lane, dev as staging when needed, and separate sensitive services only where risk truly differs."
+    },
+    {
       "id": "DOC-ASSISTANT-BRIEF",
       "name": "Assistant Brief",
       "type": "guide",

--- a/docs/decisions/0004-active-dev-promotion-model.md
+++ b/docs/decisions/0004-active-dev-promotion-model.md
@@ -1,0 +1,47 @@
+# 0004 — Active / Dev Promotion Model
+Date: 2026-04-14T20:30:00Z
+Status: Accepted
+
+## Context
+GroundMesh previously explored separate local folder copies such as `GroundMesh-ACTIVE` and
+`GroundMesh-DEV` to protect a working public surface from breaking during experimentation.
+
+That instinct was correct: public trust surfaces, uptime, and contributor-facing pages should not
+be casually destabilized by in-progress work. But long-lived folder or repo copies also create
+their own problems:
+
+- drift between copies
+- duplicate fixes and duplicated memory
+- uncertainty about which surface is canonical
+- harder recovery when many versions diverge
+
+GroundMesh now has a healthier GitHub-centered workflow with small PR-sized batches, visible
+history, and a working public deploy path from the canonical repo.
+
+## Decision
+Keep the `ACTIVE / DEV` idea, but translate it into a single canonical repo with promotion lanes.
+
+The working model is:
+
+1. `main` is the active public lane.
+   - It represents the trusted, presentable public surface.
+   - Only reviewed and verified changes should land here.
+2. `dev` is the integration and staging lane when a separate merge buffer is useful.
+   - It is for combining or checking batches before promotion to `main`.
+   - It should not become a second source of truth.
+3. Short-lived feature branches are the normal place for focused work.
+   - Use them for experiments, fixes, and discrete implementation slices.
+   - Merge or close them quickly rather than letting them become parallel worlds.
+4. Separate systems should be introduced only when the operational risk is truly different.
+   - Future registration, identity, moderation, privacy, or confidential intake services may
+     deserve separate private repos or services.
+   - Static public docs and sensitive intake should not be collapsed into the same operational
+     surface by default.
+
+## Consequences
+
+- GroundMesh keeps one canonical memory spine instead of many drifting folder copies.
+- Public stability is protected through promotion discipline rather than duplicate trees.
+- The project can keep moving in small safe batches without sacrificing uptime or clarity.
+- Future public registration can be piloted carefully in a separate sensitive layer if needed,
+  rather than being rushed into the static public docs surface.


### PR DESCRIPTION
## Why
- GroundMesh already carries the instinct to protect stable public surfaces from in-progress experiments
- older local folders like `GroundMesh-ACTIVE` and `GroundMesh-DEV` show that need clearly, but long-lived folder copies create drift and uncertainty
- the project now needs a clean recorded answer for how `ACTIVE` and `DEV` should exist going forward

## What changed
- add `ADR-0004` defining the Active / Dev promotion model
- state that the `ACTIVE / DEV` idea survives as one canonical repo with:
  - `main` as the active public lane
  - `dev` as staging when useful
  - short-lived branches for focused work
  - separate sensitive services only where the operational risk truly differs
- add a matching one-line promotion-model directive to the assistant brief
- register the decision in Atlas and regenerate the Atlas page

## Verification
- `scripts/atlas-generate.ps1`
- `scripts/health-check.ps1` reports `Live OK: 10  Live BAD: 0`
- `scripts/health-check.ps1` reports `Files OK: 13  Files MISS: 0`
