### PR TITLE
docs(registration): define pilot readiness gates

### DIFF
--- a/checklists/Registration_Pilot_Readiness_Checklist.md
+++ b/checklists/Registration_Pilot_Readiness_Checklist.md
@@ -1,0 +1,40 @@
+# Registration Pilot Readiness Checklist
+
+Use this before opening any real GroundMesh registration or declared-joining path beyond simple
+public contact.
+
+## 1) Scope is narrow and honest
+- The pilot has a named purpose.
+- The pilot has a limited cohort, circle, geography, or invitation path.
+- The first promise is smaller than the long-term mission.
+- The public copy clearly says this is a pilot if that is the truth.
+
+## 2) Consent and privacy are defined
+- The requested data fields are the minimum truly needed.
+- The participant can understand what becomes public, private, or review-only.
+- There is a clear consent statement.
+- There is a removal or correction path.
+- The storage location and access boundaries are known.
+
+## 3) Moderation and verification exist
+- Someone is explicitly responsible for reviewing submissions.
+- There is a rule for what gets accepted, paused, rejected, or escalated.
+- There is a way to flag unclear, harmful, or suspicious submissions.
+- Verification is proportional to the promise being made.
+
+## 4) Operations are real
+- The contact or intake path is monitored.
+- Expected response timing is known.
+- There is a fallback if the primary steward is unavailable.
+- There is a simple logging trail for what happened and why.
+
+## 5) Technical handling is ready
+- The intake surface is separate from the static public docs if sensitive handling is involved.
+- Basic failure, spam, and duplicate handling are considered.
+- A rollback path exists if the pilot starts causing confusion or harm.
+- The path has been tested with a small internal or trusted-circle dry run.
+
+## 6) Launch discipline holds
+- The pilot opens only after the above items are honestly green.
+- The launch is reviewed after the first real submissions.
+- Expansion happens only after demonstrated handling, not excitement alone.

--- a/docs/assistant-brief.md
+++ b/docs/assistant-brief.md
@@ -15,6 +15,7 @@
 - Unify the stronger `groundmesh-world` public seed with the Atlas-backed `GroundMesh/docs` front door.
 - Stabilize public docs (Home, Get Started, Contributors, Map, Compute, Atlas, Landscape, Contact, Privacy).
 - Surface existing donate/volunteer flow; avoid re-invention and avoid repo drift.
+- Treat future registration as a narrow pilot with real moderation, privacy, and rollback gates rather than a broad launch.
 
 ## Golden links
 - Get Started: /get-started/index.html

--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -174,11 +174,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>18</strong>
+          <strong>20</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>18</strong>
+          <strong>20</strong>
         </div>
       </div>
     </section>
@@ -243,6 +243,22 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/decisions/0004-active-dev-promotion-model.md</code></td>
   <td>Keeps the ACTIVE / DEV instinct, but translates it into one canonical repo with main as the public lane, dev as staging when needed, and separate sensitive services only where risk truly differs.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0005-public-registration-pilot.md">ADR-0005</a></td>
+  <td><strong>Public Registration Begins as a Pilot</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0005-public-registration-pilot.md</code></td>
+  <td>Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../../checklists/Registration_Pilot_Readiness_Checklist.md">CHECKLIST-REGISTRATION-PILOT</a></td>
+  <td><strong>Registration Pilot Readiness Checklist</strong></td>
+  <td><span class="chip">checklist</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>checklists/Registration_Pilot_Readiness_Checklist.md</code></td>
+  <td>Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../assistant-brief.md">DOC-ASSISTANT-BRIEF</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -33,6 +33,22 @@
       "summary": "Keeps the ACTIVE / DEV instinct, but translates it into one canonical repo with main as the public lane, dev as staging when needed, and separate sensitive services only where risk truly differs."
     },
     {
+      "id": "ADR-0005",
+      "name": "Public Registration Begins as a Pilot",
+      "type": "decision",
+      "status": "active",
+      "path": "docs/decisions/0005-public-registration-pilot.md",
+      "summary": "Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates."
+    },
+    {
+      "id": "CHECKLIST-REGISTRATION-PILOT",
+      "name": "Registration Pilot Readiness Checklist",
+      "type": "checklist",
+      "status": "active",
+      "path": "checklists/Registration_Pilot_Readiness_Checklist.md",
+      "summary": "Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact."
+    },
+    {
       "id": "DOC-ASSISTANT-BRIEF",
       "name": "Assistant Brief",
       "type": "guide",

--- a/docs/decisions/0005-public-registration-pilot.md
+++ b/docs/decisions/0005-public-registration-pilot.md
@@ -1,0 +1,45 @@
+# 0005 — Public Registration Begins as a Pilot
+Date: 2026-04-14T20:55:00Z
+Status: Accepted
+
+## Context
+GroundMesh aims to eventually support real public participation at much greater scale, including
+some form of registration or declared joining. That step matters, but the current public docs
+surface is still intentionally simple:
+
+- it is a public trust and orientation layer
+- it is not yet a hardened intake system
+- it does not yet have a full moderation, verification, or sensitive-data handling layer
+
+The repo already says this in several places, but those warnings are scattered. GroundMesh now
+needs one clear answer for how registration should begin when the time comes.
+
+## Decision
+Do not open broad public registration all at once.
+
+When GroundMesh first allows registration or declared joining beyond simple public contact, it
+should begin as a narrow pilot with explicit limits and review gates.
+
+The working model is:
+
+1. Start with a pilot, not a planetary launch.
+   - Limit scope by cohort, circle, geography, or invitation path.
+   - Keep the first promise smaller than the eventual mission.
+2. Keep the static public docs layer separate from sensitive intake.
+   - Public pages may describe the path and direct people toward it.
+   - Identity, moderation, consent records, and confidential handling should live in a separate
+     intake surface when they become real.
+3. Do not collect more than the current purpose requires.
+   - Ask for the minimum information needed.
+   - Prefer reversible, low-exposure participation paths where possible.
+4. Do not launch the pilot until the registration readiness checklist is honestly green.
+   - Moderation, consent, privacy, removal/correction, response ownership, and rollback must all
+     be defined before opening the door.
+
+## Consequences
+
+- GroundMesh preserves trust by refusing to promise more handling capacity than it actually has.
+- Public registration becomes a tested operational path rather than a symbolic announcement.
+- The project can learn from a smaller cohort before carrying wider human consequence.
+- The public docs site remains honest and useful without being forced to become a confidential
+  system prematurely.


### PR DESCRIPTION
## Why
- GroundMesh already says the current public site is not yet ready for real sensitive intake or large-scale declared joining
- the project needs a clean recorded answer for how registration should begin when the time comes
- the right move is a narrow pilot with explicit gates, not a broad symbolic launch

## What changed
- add `ADR-0005` defining public registration as a pilot-first path
- add a registration pilot readiness checklist with scope, consent, moderation, operations, technical, and launch gates
- add a matching line to the assistant brief so day-to-day work stays aligned with this posture
- register the decision and checklist in Atlas and regenerate the Atlas page

## Verification
- `scripts/atlas-generate.ps1`
- `scripts/health-check.ps1` reports `Live OK: 10  Live BAD: 0`
- `scripts/health-check.ps1` reports `Files OK: 13  Files MISS: 0`
