### PR TITLE
docs(site): add honest registration status page

### DIFF
--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -174,11 +174,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>20</strong>
+          <strong>21</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>20</strong>
+          <strong>21</strong>
         </div>
       </div>
     </section>
@@ -355,6 +355,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/privacy.html</code></td>
   <td>Plain-language statement of the current public privacy posture, limits, and data-minimization rule.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../register.html">PAGE-REGISTER</a></td>
+  <td><strong>GroundMesh Registration Status</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/register.html</code></td>
+  <td>Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../data/status.json">STATUS-PUBLIC</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -100,6 +100,14 @@
       "summary": "Simple public contact path for questions, corrections, first contact, and participation guidance."
     },
     {
+      "id": "PAGE-REGISTER",
+      "name": "GroundMesh Registration Status",
+      "type": "page",
+      "status": "active",
+      "path": "docs/register.html",
+      "summary": "Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot."
+    },
+    {
       "id": "PAGE-GET-STARTED",
       "name": "GroundMesh Get Started",
       "type": "page",

--- a/docs/contribute.html
+++ b/docs/contribute.html
@@ -35,6 +35,7 @@
         <a class="btn" href="https://github.com/mailgmirko-creator/groundmesh/issues/new?template=add_my_pin.yml" rel="noopener">Add my pin (GitHub)</a>
         <a class="btn" href="map.html" rel="noopener">See the living map</a>
         <a class="btn" href="https://github.com/mailgmirko-creator/groundmesh/issues/new?template=feature_request.yml&title=%5BFeature%5D%3A+" rel="noopener">New Feature / Improvement</a>
+        <a class="btn" href="register.html" rel="noopener">Registration Status</a>
         <a class="btn" href="contributors-quickstart.md" rel="noopener">Quickstart (Markdown)</a>
         <a class="btn" href="get-started/index.html" rel="noopener">Developer Get Started</a>
         <a class="btn" href="contact.html" rel="noopener">Contact</a>
@@ -61,6 +62,12 @@
         <h2>Feature ideas</h2>
         <p>Write what you want to see — Purpose, User Story, Inputs/Outputs, and 2–3 Acceptance Criteria.</p>
         <p><a class="inline" href="https://github.com/mailgmirko-creator/groundmesh/issues/new?template=feature_request.yml&title=%5BFeature%5D%3A+">Open Feature / Improvement</a></p>
+      </div>
+
+      <div class="card">
+        <h2>Declared joining / registration</h2>
+        <p>If you are looking for a fuller joining or registration path, read the current status page first. GroundMesh is still opening that path carefully as a future pilot, not as a broad intake yet.</p>
+        <p><a class="inline" href="register.html">Open Registration Status</a></p>
       </div>
 
       <div class="card">

--- a/docs/data/status.json
+++ b/docs/data/status.json
@@ -1,5 +1,5 @@
 {
-  "updated_utc": "2026-04-14T08:20:00Z",
+  "updated_utc": "2026-04-15T08:19:08Z",
   "components": {
     "deployment_source": {
       "status": "green",
@@ -12,6 +12,10 @@
     "contributors_page": {
       "status": "green",
       "note": "Contributors route loads publicly"
+    },
+    "registration_page": {
+      "status": "yellow",
+      "note": "Registration status page is prepared locally as the honest public path for future joining and will turn green after publish"
     },
     "get_started_page": {
       "status": "green",

--- a/docs/index.html
+++ b/docs/index.html
@@ -195,6 +195,7 @@
         <a class="nav-link" href="#join">Join</a>
         <a class="nav-link" href="#support">Support</a>
         <a class="nav-link" href="#trust">Trust</a>
+        <a class="nav-link" href="register.html">Register</a>
         <a class="nav-link" href="get-started/index.html">Get Started</a>
         <a class="nav-link" href="atlas/index.html">Atlas</a>
         <a class="nav-link" href="contribute.html">Contribute</a>
@@ -241,6 +242,7 @@
 
     <section class="surface-grid">
       <article class="card"><h3>Get Started</h3><p>The clearest first stop for builders who want the repo, checks, and safe contribution path.</p><a href="get-started/index.html">Open Get Started</a></article>
+      <article class="card"><h3>Register</h3><p>The current public status page for joining, declared participation, and what is not open yet.</p><a href="register.html">Open Registration Status</a></article>
       <article class="card"><h3>Atlas</h3><p>See what already exists before adding anything new.</p><a href="atlas/index.html">Open Atlas</a></article>
       <article class="card"><h3>Contribute</h3><p>The low-friction public on-ramp for people who want to help.</p><a href="contribute.html">Open Contributors Hub</a></article>
       <article class="card"><h3>Map</h3><p>The public orientation layer for visible relation and participation.</p><a href="map.html">Open the Map</a></article>
@@ -297,7 +299,8 @@
       </div>
       <div class="box">
         <h3>Current best path</h3>
-        <p>Use <code>Get Started</code> if you want to help build the project itself, or the contributors flow if you want the lighter public entry path.</p>
+        <p>Use <code>Registration</code> to see the current joining status, <code>Get Started</code> if you want to help build the project itself, or the contributors flow if you want the lighter public entry path.</p>
+        <a href="register.html">Open Registration Status</a><br />
         <a href="get-started/index.html">Open Get Started</a><br />
         <a href="contribute.html">Go to Contributors</a>
       </div>

--- a/docs/register.html
+++ b/docs/register.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>GroundMesh Registration</title>
+  <style>
+    :root { --bg:#0b0b0c; --card:#141417; --text:#e9e9ee; --muted:#b8b8c3; --line:#23232a; --accent:#6ee7b7; --accent2:#93c5fd; --warn:#ffd7a8; }
+    * { box-sizing:border-box; }
+    body { margin:0; background:var(--bg); color:var(--text); font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Noto Sans",sans-serif; line-height:1.5; }
+    .wrap { max-width:980px; margin:0 auto; padding:28px 20px 56px; }
+    .hero, .card { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:20px; }
+    .hero { margin-bottom:16px; }
+    .eyebrow { text-transform:uppercase; letter-spacing:.18em; color:var(--accent); font-size:.75rem; font-weight:700; margin-bottom:12px; }
+    h1 { font-size:clamp(1.8rem,3vw,2.8rem); margin:0 0 12px; }
+    h2 { font-size:1.1rem; margin:0 0 10px; }
+    p, li { color:var(--muted); }
+    .grid { display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); margin-top:16px; }
+    .cta { display:flex; flex-wrap:wrap; gap:12px; margin-top:16px; }
+    .btn { display:inline-block; text-decoration:none; padding:10px 14px; border-radius:10px; border:1px solid #2a2a33; background:#1a1a20; color:var(--text); font-weight:600; }
+    .notice { border-left:4px solid var(--warn); padding-left:12px; color:var(--text); }
+    ul { margin:8px 0 0 18px; }
+    code { background:rgba(255,255,255,.08); padding:2px 6px; border-radius:6px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <section class="hero">
+      <div class="eyebrow">Registration status</div>
+      <h1>GroundMesh registration is not broadly open yet.</h1>
+      <p>
+        GroundMesh intends to support real declared joining and wider participation in time,
+        but that path must begin as a careful pilot with real moderation, privacy, consent, and
+        rollback gates behind it.
+      </p>
+      <p class="notice">
+        For now, use the current public paths below. Do not treat this site as a confidential
+        intake or emergency registration system.
+      </p>
+      <div class="cta">
+        <a class="btn" href="contribute.html">Open Contributors Hub</a>
+        <a class="btn" href="contact.html">Contact GroundMesh</a>
+        <a class="btn" href="privacy.html">Privacy</a>
+        <a class="btn" href="atlas/index.html">Atlas</a>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <h2>What works right now</h2>
+        <ul>
+          <li>First contact through the public contact page</li>
+          <li>Low-friction participation through the contributors hub</li>
+          <li>Public map pin requests with explicit consent</li>
+          <li>Builder participation through <code>Get Started</code></li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>What is not open yet</h2>
+        <ul>
+          <li>Broad public registration at planetary scale</li>
+          <li>Confidential or sensitive identity intake on the static docs site</li>
+          <li>Emergency handling promises beyond the current public trust layer</li>
+          <li>Automated acceptance without human review</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>How it will open</h2>
+        <p>
+          The first real registration path should open as a narrow pilot, not a symbolic mass
+          launch. Scope, consent, moderation, operations, and rollback must all be honestly green
+          first.
+        </p>
+        <p><a href="decisions/0005-public-registration-pilot.md">Read the pilot decision</a></p>
+      </article>
+    </section>
+  </div>
+</body>
+</html>

--- a/scripts/health-check.ps1
+++ b/scripts/health-check.ps1
@@ -5,6 +5,7 @@ param(
 $urls = @(
   "$Base/",
   "$Base/contribute.html",
+  "$Base/register.html",
   "$Base/get-started/index.html",
   "$Base/map.html",
   "$Base/contact.html",
@@ -18,6 +19,7 @@ $urls = @(
 $files = @(
   "docs/index.html",
   "docs/contribute.html",
+  "docs/register.html",
   "docs/get-started/index.html",
   "docs/map.html",
   "docs/contact.html",


### PR DESCRIPTION
## Why
- GroundMesh now has a clear internal decision for pilot-first registration, but the public site still makes people infer that state from scattered notes
- the next smallest useful step is one honest public page that says what is open, what is not, and where people should go right now
- this improves clarity without opening registration early or pretending more handling exists than is real

## What changed
- add `docs/register.html` as the public registration status page
- link to it from the main front door and contributors hub
- register the page in Atlas
- update `status.json` and `health-check.ps1` so the new route becomes part of project memory and checks

## Verification
- `scripts/atlas-generate.ps1`
- `scripts/health-check.ps1` reports `Files OK: 14  Files MISS: 0`
- `scripts/health-check.ps1` reports `Live OK: 10  Live BAD: 1` before publish, with the single expected red being `/register.html`
