### PR TITLE
docs(status): mark registration page live

### DIFF
--- a/docs/data/status.json
+++ b/docs/data/status.json
@@ -1,5 +1,5 @@
 {
-  "updated_utc": "2026-04-15T08:19:08Z",
+  "updated_utc": "2026-04-15T08:30:00Z",
   "components": {
     "deployment_source": {
       "status": "green",
@@ -14,8 +14,8 @@
       "note": "Contributors route loads publicly"
     },
     "registration_page": {
-      "status": "yellow",
-      "note": "Registration status page is prepared locally as the honest public path for future joining and will turn green after publish"
+      "status": "green",
+      "note": "Registration status page now loads publicly as the honest path for joining status and pilot-first registration posture"
     },
     "get_started_page": {
       "status": "green",

--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -110,7 +110,7 @@
       <div class="eyebrow">GroundMesh Landscape</div>
       <h1>What exists here, on the web, and around the project right now.</h1>
       <p>
-        This page is a broad scan of the GroundMesh ecosystem as checked on April 14, 2026.
+        This page is a broad scan of the GroundMesh ecosystem as checked on April 15, 2026.
         It separates the public-facing surfaces, local repos, and adjacent operational experiments
         so we can grow from what is already real instead of duplicating it blindly.
       </p>
@@ -135,6 +135,12 @@
         <h3>GroundMesh Atlas</h3>
         <p>The Atlas route now responds successfully along with the wider docs surface.</p>
         <a href="https://mailgmirko-creator.github.io/groundmesh/atlas/index.html">Open live Atlas</a>
+      </article>
+      <article class="card">
+        <div class="status ok">Live now</div>
+        <h3>GroundMesh Registration Status</h3>
+        <p>The public registration status page is now live and gives one honest place to understand what is open and what is not.</p>
+        <a href="https://mailgmirko-creator.github.io/groundmesh/register.html">Open live Registration Status</a>
       </article>
       <article class="card">
         <div class="status ok">Live now</div>


### PR DESCRIPTION
## Why
- the registration status page is now live publicly, but GroundMesh's own status snapshot and landscape page still describe it as pre-publish or omit it from the confirmed live set
- the smallest honest follow-up is to make project memory match current reality

## What changed
- mark `registration_page` green in `docs/data/status.json`
- update `docs/landscape.html` to include the live registration status page in the confirmed live pages section and refresh the checked date

## Verification
- `scripts/health-check.ps1` reports `Live OK: 11  Live BAD: 0`
- `scripts/health-check.ps1` reports `Files OK: 14  Files MISS: 0`
