### PR TITLE
docs(status): mark registration checklist live

### DIFF
--- a/docs/data/status.json
+++ b/docs/data/status.json
@@ -1,5 +1,5 @@
 {
-  "updated_utc": "2026-04-15T08:30:00Z",
+  "updated_utc": "2026-04-15T09:05:00Z",
   "components": {
     "deployment_source": {
       "status": "green",
@@ -16,6 +16,10 @@
     "registration_page": {
       "status": "green",
       "note": "Registration status page now loads publicly as the honest path for joining status and pilot-first registration posture"
+    },
+    "registration_checklist": {
+      "status": "green",
+      "note": "Registration pilot readiness checklist now loads publicly from the docs surface and matches the live Atlas and registration path"
     },
     "get_started_page": {
       "status": "green",

--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -144,6 +144,12 @@
       </article>
       <article class="card">
         <div class="status ok">Live now</div>
+        <h3>Registration readiness checklist</h3>
+        <p>The public checklist behind the pilot-first registration posture is now live too, so the readiness gate is visible and inspectable.</p>
+        <a href="https://mailgmirko-creator.github.io/groundmesh/checklists/Registration_Pilot_Readiness_Checklist.md">Open live checklist</a>
+      </article>
+      <article class="card">
+        <div class="status ok">Live now</div>
         <h3>GroundMesh World</h3>
         <p>The newer standalone public seed is also live on GitHub Pages.</p>
         <a href="https://mailgmirko-creator.github.io/groundmesh-world/">Open GroundMesh World</a>


### PR DESCRIPTION
## Why
The registration pilot readiness checklist is now live on the public docs surface after PR #26, so GroundMesh's own status snapshot and landscape page should say that plainly.

## What Changed
- updated `status.json` to add a green `registration_checklist` component and refreshed the timestamp
- added the live checklist to the confirmed live pages section on `landscape.html`

## Impact
GroundMesh's public memory now matches the real published site more closely, and people exploring the live surface can see that the registration readiness gate is public too.

## Validation
- ran `./scripts/health-check.ps1`
- result: `Live OK: 12`, `Live BAD: 0`, `Files OK: 15`, `Files MISS: 0`
