### PR TITLE
docs: surface registration checklist from public entry paths

### DIFF
--- a/docs/contribute.html
+++ b/docs/contribute.html
@@ -68,6 +68,7 @@
         <h2>Declared joining / registration</h2>
         <p>If you are looking for a fuller joining or registration path, read the current status page first. GroundMesh is still opening that path carefully as a future pilot, not as a broad intake yet.</p>
         <p><a class="inline" href="register.html">Open Registration Status</a></p>
+        <p><a class="inline" href="checklists/Registration_Pilot_Readiness_Checklist.md">Open the readiness checklist</a></p>
       </div>
 
       <div class="card">

--- a/docs/index.html
+++ b/docs/index.html
@@ -301,6 +301,7 @@
         <h3>Current best path</h3>
         <p>Use <code>Registration</code> to see the current joining status, <code>Get Started</code> if you want to help build the project itself, or the contributors flow if you want the lighter public entry path.</p>
         <a href="register.html">Open Registration Status</a><br />
+        <a href="checklists/Registration_Pilot_Readiness_Checklist.md">Open Registration Readiness Checklist</a><br />
         <a href="get-started/index.html">Open Get Started</a><br />
         <a href="contribute.html">Go to Contributors</a>
       </div>
@@ -338,6 +339,7 @@
           <li>Keep the privacy and data-minimization posture current</li>
           <li>Replace prototype forms with a real intake method</li>
           <li>Create a moderation and verification review process</li>
+          <li>Keep the public <a href="checklists/Registration_Pilot_Readiness_Checklist.md">registration readiness checklist</a> honestly green before opening intake</li>
           <li>Keep the first promise smaller than the eventual mission</li>
         </ul>
       </div>


### PR DESCRIPTION
## Why
The registration pilot readiness checklist is now live, but it was still mostly discoverable only through the registration page and Atlas. The front door and contributors hub should point to that honesty gate too.

## What Changed
- added a direct checklist link in the front door join section
- added a checklist reminder to the front door launch guidance
- added a direct checklist link to the contributors hub registration card

## Impact
People arriving through the main public pages can now find the registration readiness gate more easily without hunting through Atlas or guessing where the pilot criteria live.

## Validation
- ran `./scripts/health-check.ps1`
- result: `Live OK: 12`, `Live BAD: 0`, `Files OK: 15`, `Files MISS: 0`
