### PR TITLE
docs: add minimal registration interest signal path

### DIFF
--- a/docs/contact.html
+++ b/docs/contact.html
@@ -28,7 +28,18 @@
       <p>Email is the current human contact path:</p>
       <p><code>mailgmirko@gmail.com</code></p>
       <a class="btn" href="mailto:mailgmirko@gmail.com?subject=GroundMesh%20Contact">Email GroundMesh</a>
+      <a class="btn" href="mailto:mailgmirko@gmail.com?subject=GroundMesh%20Registration%20Interest&body=Region%20or%20country%3A%20%0AParticipation%20type%20(public%20declaration%2C%20pseudonymous%2C%20builder%2C%20local%20circle)%3A%20%0AContact%20preference%3A%20%0ANote%20(optional)%3A%20%0A%0AConsent%3A%20I%20understand%20this%20is%20ordinary%20email%20and%20not%20a%20confidential%20intake%20channel.">Signal Registration Interest</a>
       <a class="btn" href="contribute.html">Open Contributors Hub</a>
+    </div>
+
+    <div class="card">
+      <h2>Registration interest</h2>
+      <p>
+        If you want to express interest in future declared joining or pilot registration, use the
+        dedicated email button above and keep the first message minimal. Do not send passports,
+        identity numbers, private addresses, or emergency-only information through ordinary email.
+      </p>
+      <p><a class="btn" href="register.html">Open Registration Status</a> <a class="btn" href="privacy.html">Open Privacy</a></p>
     </div>
 
     <div class="card">

--- a/docs/register.html
+++ b/docs/register.html
@@ -57,6 +57,19 @@
       </article>
 
       <article class="card">
+        <h2>If you want to signal interest now</h2>
+        <p>
+          Use a minimal first-contact note rather than sending sensitive identity material. A good
+          first message is enough to say your region or country, what kind of participation you are
+          interested in, and whether you prefer public, pseudonymous, or private follow-up.
+        </p>
+        <p>
+          <a href="mailto:mailgmirko@gmail.com?subject=GroundMesh%20Registration%20Interest&body=Region%20or%20country%3A%20%0AParticipation%20type%20(public%20declaration%2C%20pseudonymous%2C%20builder%2C%20local%20circle)%3A%20%0AContact%20preference%3A%20%0ANote%20(optional)%3A%20%0A%0AConsent%3A%20I%20understand%20this%20is%20ordinary%20email%20and%20not%20a%20confidential%20intake%20channel.">Send a minimal interest note</a>
+        </p>
+        <p><a href="contact.html">Open Contact</a> · <a href="privacy.html">Open Privacy</a></p>
+      </article>
+
+      <article class="card">
         <h2>What is not open yet</h2>
         <ul>
           <li>Broad public registration at planetary scale</li>


### PR DESCRIPTION
## Why
The registration page honestly says broad intake is not open yet, but it still needed a clearer safe path for people who want to express interest now without treating the site like a real registration backend.

## What Changed
- added a new card on the registration page explaining how to send a minimal first-contact interest note
- added a prefilled mailto link for registration interest with minimal fields and an explicit ordinary-email consent note
- added the same dedicated interest action and caution language to the contact page

## Impact
People can now signal interest in future declared joining or pilot registration without guessing what to send, while GroundMesh still preserves the current boundary against sensitive or overpromised intake.

## Validation
- ran `./scripts/health-check.ps1`
- result: `Live OK: 12`, `Live BAD: 0`, `Files OK: 15`, `Files MISS: 0`
