### PR TITLE
docs: add registration pilot scope canvas

### DIFF
--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -174,11 +174,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>21</strong>
+          <strong>22</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>21</strong>
+          <strong>22</strong>
         </div>
       </div>
     </section>
@@ -371,6 +371,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/data/status.json</code></td>
   <td>Tracks public health notes for the current docs surface and Atlas-backed pages.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../templates/Registration_Pilot_Scope_Canvas.md">TEMPLATE-REGISTRATION-PILOT-SCOPE</a></td>
+  <td><strong>Registration Pilot Scope Canvas</strong></td>
+  <td><span class="chip">template</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/templates/Registration_Pilot_Scope_Canvas.md</code></td>
+  <td>Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../protocols/TP-03.md">TP-03</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -49,6 +49,14 @@
       "summary": "Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact."
     },
     {
+      "id": "TEMPLATE-REGISTRATION-PILOT-SCOPE",
+      "name": "Registration Pilot Scope Canvas",
+      "type": "template",
+      "status": "active",
+      "path": "docs/templates/Registration_Pilot_Scope_Canvas.md",
+      "summary": "Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact."
+    },
+    {
       "id": "DOC-ASSISTANT-BRIEF",
       "name": "Assistant Brief",
       "type": "guide",

--- a/docs/register.html
+++ b/docs/register.html
@@ -88,6 +88,7 @@
         </p>
         <p><a href="decisions/0005-public-registration-pilot.md">Read the pilot decision</a></p>
         <p><a href="checklists/Registration_Pilot_Readiness_Checklist.md">Read the readiness checklist</a></p>
+        <p><a href="templates/Registration_Pilot_Scope_Canvas.md">Read the pilot scope canvas</a></p>
       </article>
     </section>
   </div>

--- a/docs/templates/Registration_Pilot_Scope_Canvas.md
+++ b/docs/templates/Registration_Pilot_Scope_Canvas.md
@@ -1,0 +1,70 @@
+# Registration Pilot Scope Canvas
+
+Use this when GroundMesh is genuinely nearing its first real registration or declared-joining pilot.
+This is not the launch itself. It is the smallest honest sheet for defining what the first pilot is.
+
+## Pilot name
+- Working title:
+- Date prepared:
+- Steward / owner:
+- Backup steward:
+
+## Purpose
+- What is this pilot for?
+- What real need does it serve right now?
+- What is the smallest promise being made?
+
+## Cohort and invitation path
+- Who is this for?
+- How limited is the first cohort?
+- Is this by geography, known circle, invitation, or another narrow path?
+- Who is explicitly out of scope for this first run?
+
+## Participation types allowed
+- Public declaration
+- Pseudonymous participation
+- Builder / contributor
+- Local circle / node interest
+- Other:
+
+## Minimal data requested
+- Region or country:
+- Contact preference:
+- Participation type:
+- Optional note:
+- Anything else:
+
+Only ask for what the first purpose truly requires.
+
+## Public / private boundary
+- What becomes public, if anything?
+- What remains private or review-only?
+- What should never be sent through ordinary email?
+- Where will sensitive handling live if it becomes necessary?
+
+## Review and moderation
+- Who reads submissions?
+- How often is the channel checked?
+- What is the response target?
+- What leads to accept / pause / reject / escalate?
+
+## Verification level
+- What level of verification is appropriate for this first promise?
+- What can remain self-declared?
+- What requires follow-up before any stronger claim is made?
+
+## Success and stop conditions
+- What would count as a successful first pilot?
+- What volume is still safe?
+- What confusion or harm would trigger pause or rollback?
+
+## Dry run and review
+- Dry run completed on:
+- First review date:
+- Expansion decision date:
+
+## Out of scope for this pilot
+- Broad planetary intake
+- Confidential identity collection through the static docs site
+- Emergency promises beyond actual handling capacity
+- Any other explicit non-goals:


### PR DESCRIPTION
## Why
GroundMesh already had the pilot decision, the readiness checklist, and the public interest signal, but it still lacked one concrete fill-in sheet for defining the first real pilot when the time comes.

## What Changed
- added a public `Registration Pilot Scope Canvas` under `docs/templates/`
- registered the new canvas in Atlas and regenerated the Atlas page
- linked the canvas from the registration page alongside the pilot decision and readiness checklist

## Impact
GroundMesh now has a practical next rung between "not open yet" and "open the pilot": a small reusable canvas for naming the cohort, owner, minimal fields, review path, and stop conditions before any real intake begins.

## Validation
- ran `./scripts/atlas-generate.ps1`
- ran `./scripts/health-check.ps1`
- result: `Live OK: 12`, `Live BAD: 0`, `Files OK: 15`, `Files MISS: 0`
