### PR TITLE
docs: connect registration pilot canvas to issue flow

### DIFF
--- a/docs/templates/Registration_Pilot_Scope_Canvas.md
+++ b/docs/templates/Registration_Pilot_Scope_Canvas.md
@@ -3,6 +3,14 @@
 Use this when GroundMesh is genuinely nearing its first real registration or declared-joining pilot.
 This is not the launch itself. It is the smallest honest sheet for defining what the first pilot is.
 
+Related:
+- [Pilot decision](../decisions/0005-public-registration-pilot.md)
+- [Readiness checklist](../checklists/Registration_Pilot_Readiness_Checklist.md)
+- [Registration pilot proposal issue form](https://github.com/mailgmirko-creator/groundmesh/issues/new?template=registration_pilot.yml)
+
+When this canvas becomes concrete enough to track, open the GitHub issue form above and carry the
+filled sections into one visible proposal.
+
 ## Pilot name
 - Working title:
 - Date prepared:


### PR DESCRIPTION
## Why
GroundMesh now has the pilot scope canvas and the registration pilot issue form, but the canvas itself should point directly to the tracked GitHub planning path so the steward workflow is one continuous line.

## What Changed
- added related links at the top of the registration pilot scope canvas
- linked the canvas to the pilot decision, readiness checklist, and GitHub `registration_pilot.yml` issue form
- added a short note telling stewards to carry a concrete canvas into one visible proposal issue

## Impact
The first real registration pilot can now move more cleanly from document drafting into tracked repo planning without guesswork or scattered handoff.

## Validation
- reviewed the updated markdown content locally
- no runtime or public-site checks were needed because this change only updates a markdown template
