### PR TITLE
docs: add registration interest triage checklist

### DIFF
--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -174,11 +174,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>22</strong>
+          <strong>23</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>22</strong>
+          <strong>23</strong>
         </div>
       </div>
     </section>
@@ -251,6 +251,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/decisions/0005-public-registration-pilot.md</code></td>
   <td>Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../checklists/Registration_Interest_Triage_Checklist.md">CHECKLIST-REGISTRATION-INTEREST-TRIAGE</a></td>
+  <td><strong>Registration Interest Triage Checklist</strong></td>
+  <td><span class="chip">checklist</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/checklists/Registration_Interest_Triage_Checklist.md</code></td>
+  <td>Smallest honest handling checklist for public registration-interest emails before any real pilot intake is open.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../checklists/Registration_Pilot_Readiness_Checklist.md">CHECKLIST-REGISTRATION-PILOT</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -49,6 +49,14 @@
       "summary": "Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact."
     },
     {
+      "id": "CHECKLIST-REGISTRATION-INTEREST-TRIAGE",
+      "name": "Registration Interest Triage Checklist",
+      "type": "checklist",
+      "status": "active",
+      "path": "docs/checklists/Registration_Interest_Triage_Checklist.md",
+      "summary": "Smallest honest handling checklist for public registration-interest emails before any real pilot intake is open."
+    },
+    {
       "id": "TEMPLATE-REGISTRATION-PILOT-SCOPE",
       "name": "Registration Pilot Scope Canvas",
       "type": "template",

--- a/docs/checklists/Registration_Interest_Triage_Checklist.md
+++ b/docs/checklists/Registration_Interest_Triage_Checklist.md
@@ -1,0 +1,49 @@
+# Registration Interest Triage Checklist
+
+Use this for the current public email-based interest path before any real pilot intake is open.
+This is not a confidential handling system. It is a smallest honest checklist for calm first review.
+
+## 1) Acknowledge safely
+- Confirm receipt if a reply is appropriate.
+- Remind the sender that ordinary email is not a confidential intake channel.
+- Do not imply acceptance into a pilot or promise more handling capacity than GroundMesh actually has.
+
+## 2) Check for overshared sensitive material
+- Look for passports, identity numbers, private addresses, emergency-only information, or other unnecessary sensitive details.
+- If overshared material arrived, ask the sender not to resend it through ordinary email.
+- Keep any follow-up focused on the minimum needed signal.
+
+## 3) Record only the smallest useful signal
+- Date received:
+- Steward reviewing:
+- Region or country:
+- Participation type:
+- Contact preference:
+- Short note:
+
+Do not create a larger private dossier than the current purpose requires.
+
+## 4) Classify the interest
+- Public declaration interest
+- Pseudonymous participation interest
+- Builder / contributor interest
+- Local circle / node interest
+- Unclear / needs clarification
+
+## 5) Reply with the smallest honest next step
+- Point builders toward `Get Started`.
+- Point lighter public participants toward `Contribute`.
+- Point privacy questions back to `Privacy`.
+- If the registration pilot is not open for their case, say so plainly.
+- If clarification is needed, ask only the next necessary question.
+
+## 6) Pause or escalate when needed
+- Pause if the message asks for emergency handling GroundMesh does not yet provide.
+- Pause if the message is threatening, manipulative, clearly harmful, or suspicious.
+- Pause if volume exceeds current human handling capacity.
+- Escalate only to the currently named steward path.
+
+## 7) Preserve correction and withdrawal
+- Honor reasonable correction or removal requests.
+- Keep notes minimal and reversible where possible.
+- If no follow-up is appropriate, let the thread rest rather than creating artificial motion.

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -40,6 +40,7 @@
         identity numbers, private addresses, or emergency-only information through ordinary email.
       </p>
       <p><a class="btn" href="register.html">Open Registration Status</a> <a class="btn" href="privacy.html">Open Privacy</a></p>
+      <p><a class="btn" href="checklists/Registration_Interest_Triage_Checklist.md">Open Handling Checklist</a></p>
     </div>
 
     <div class="card">

--- a/docs/register.html
+++ b/docs/register.html
@@ -67,6 +67,7 @@
           <a href="mailto:mailgmirko@gmail.com?subject=GroundMesh%20Registration%20Interest&body=Region%20or%20country%3A%20%0AParticipation%20type%20(public%20declaration%2C%20pseudonymous%2C%20builder%2C%20local%20circle)%3A%20%0AContact%20preference%3A%20%0ANote%20(optional)%3A%20%0A%0AConsent%3A%20I%20understand%20this%20is%20ordinary%20email%20and%20not%20a%20confidential%20intake%20channel.">Send a minimal interest note</a>
         </p>
         <p><a href="contact.html">Open Contact</a> · <a href="privacy.html">Open Privacy</a></p>
+        <p><a href="checklists/Registration_Interest_Triage_Checklist.md">Read the current handling checklist</a></p>
       </article>
 
       <article class="card">


### PR DESCRIPTION
## Why
GroundMesh now invites minimal registration-interest emails, but the project still needed one honest handling checklist for those first messages so the path stays calm, minimal, and transparent.

## What Changed
- added a new public `Registration Interest Triage Checklist`
- registered it in Atlas and regenerated the Atlas page
- linked it from the registration page and the contact page

## Impact
The current interest-signal path now has a visible handling rule behind it: acknowledge safely, avoid overshared sensitive data, record only the smallest useful signal, classify the interest, reply with the smallest honest next step, and pause when the request exceeds current capacity.

## Validation
- ran `./scripts/atlas-generate.ps1`
- ran `./scripts/health-check.ps1`
- result: `Live OK: 12`, `Live BAD: 0`, `Files OK: 15`, `Files MISS: 0`
