### PR TITLE
docs: prepare first invited-circle registration pilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ sandboxes/TinySelfLearner_snapshot/web/app.py.bak-*
 .bridge-wt/
 public-bridge/*.log
 public-bridge/*.txt
+
+# Local-only registration pilot records
+private/registration_pilot/

--- a/docs/templates/Registration_Pilot_Record.md
+++ b/docs/templates/Registration_Pilot_Record.md
@@ -1,0 +1,34 @@
+# Registration Pilot Record Template
+
+Use this template for one actual participant record during a narrow invited-circle registration pilot.
+Do not commit filled records to the public repo. Keep actual records in a local-only path.
+
+## Record
+- Record ID:
+- Date received:
+- Steward reviewing:
+- Current status: received / clarified / accepted for pilot / paused / declined
+
+## Participant signal
+- Display or chosen name:
+- Region or country:
+- Participation type:
+- Contact preference:
+- Short note:
+
+## Consent and privacy
+- Sender understood this was ordinary email, not a confidential intake channel: yes / no
+- Any request for privacy, pseudonymity, or public declaration:
+- Any correction or removal request:
+
+## Triage outcome
+- Overshared sensitive material present: yes / no
+- Clarification needed: yes / no
+- Smallest honest next step:
+
+## Steward notes
+- Minimal internal note:
+- Follow-up date:
+- Pause or escalation reason, if any:
+
+Keep this to the minimum needed for the current pilot.

--- a/proposals/20260415_first-registration-pilot-invited-circle.md
+++ b/proposals/20260415_first-registration-pilot-invited-circle.md
@@ -1,0 +1,88 @@
+# First Registration Pilot: Invited Circle
+
+## Purpose (why)
+GroundMesh is now strong enough to test a first real registration path, but not yet strong enough
+for broad public intake. This pilot exists to prove the smallest honest loop:
+
+- one real self-registration
+- a few invited trusted friends
+- minimal data
+- calm review
+- no overpromising
+
+## Pilot shape
+- Pilot name: Invited Circle First Registration Pilot
+- Steward / owner: Mirko Giljaca
+- Backup steward: to be named before wider handling
+- Cohort: Mirko first, then a few personally invited trusted friends
+- Invitation path: direct invitation only
+- Initial safe volume: 1 self-registration plus up to 5 additional invited participants
+
+## Smallest promise
+GroundMesh can currently offer:
+
+- a real signal of declared interest
+- careful first review
+- honest communication about what is and is not open
+- a tiny invited-circle pilot with minimal data handling
+
+GroundMesh cannot yet offer:
+
+- broad planetary registration
+- confidential secure intake
+- emergency handling
+- automatic acceptance
+
+## Minimal data requested
+- display or chosen name
+- region or country
+- participation type
+- contact preference
+- optional short note
+
+No passports, identity numbers, private addresses, or emergency-only information should be
+requested or stored in this phase.
+
+## Participation types allowed
+- public declaration interest
+- pseudonymous participation interest
+- builder / contributor interest
+- local circle / node interest
+
+## Review path
+- Mirko reviews the first registrations personally
+- the public email-based interest path and triage checklist are used
+- each participant gets the smallest honest next response
+- ambiguous, harmful, or oversized cases are paused rather than forced forward
+
+## Success conditions
+- Mirko completes the first self-registration record cleanly
+- 2 to 5 invited friends can complete the same process without confusion
+- no sensitive oversharing is needed
+- the handling load remains calm and human-manageable
+- the privacy boundary stays clear
+
+## Stop conditions
+- more than 5 invited friend registrations arrive before the flow feels stable
+- sensitive identity material starts arriving through ordinary email
+- requests for emergency handling appear
+- the steward load becomes unclear or overloaded
+- the current public copy creates confusion about what is open
+
+## Explicit non-goals
+- broad public rollout
+- posting the registration link as if the full system is already open
+- collecting confidential identity material through the static docs site
+- presenting the pilot as a planetary launch
+
+## First dry run
+1. Create the first local-only self-registration record.
+2. Review it against the registration interest triage checklist.
+3. Adjust wording or fields only if the dry run shows a real problem.
+4. Invite a very small trusted circle.
+5. Review after the first few registrations before going wider.
+
+## Notes
+If this pilot goes well, the next step is not immediate mass opening. The next step is a review of
+what worked, what confused people, what data was actually needed, and whether a safer intake layer
+is required before wider public sharing.


### PR DESCRIPTION
## Why
GroundMesh now has the registration pilot scaffolding, and Mirko wants to begin the first real dry run with himself and a few close invited friends. The missing prep was one concrete invited-circle pilot proposal plus a clear record template and local-only storage pattern.

## What Changed
- added `proposals/20260415_first-registration-pilot-invited-circle.md`
- added `docs/templates/Registration_Pilot_Record.md`
- updated `.gitignore` so `private/registration_pilot/` stays local-only and never leaks into the public repo

## Impact
GroundMesh now has a concrete first-pilot plan anchored in the repo, plus a reusable participant record template. Actual filled registration records can be kept locally without being committed publicly.

## Validation
- reviewed the proposal and record template locally
- no site/runtime checks were needed because this change does not modify live public routes
