### PR TITLE
pilot: add local-network launch mode

### DIFF
--- a/scripts/start-registration-pilot.ps1
+++ b/scripts/start-registration-pilot.ps1
@@ -1,10 +1,12 @@
 param(
   [int]$Port = 8787,
-  [switch]$OpenBrowser
+  [switch]$OpenBrowser,
+  [switch]$AllowLan
 )
 
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 $ServerPath = Join-Path $RepoRoot "tools/registration_pilot_server.py"
+$HostAddress = if ($AllowLan) { "0.0.0.0" } else { "127.0.0.1" }
 
 if (!(Test-Path $ServerPath)) {
   throw "Registration pilot server not found: $ServerPath"
@@ -15,17 +17,49 @@ if (-not $python) {
   $py = Get-Command py -ErrorAction SilentlyContinue
   if ($py) {
     $pythonExe = $py.Source
-    $pythonArgs = @("-3", $ServerPath, "--port", $Port)
+    $pythonArgs = @("-3", $ServerPath, "--host", $HostAddress, "--port", $Port)
   } else {
     throw "Python was not found on PATH."
   }
 } else {
   $pythonExe = $python.Source
-  $pythonArgs = @($ServerPath, "--port", $Port)
+  $pythonArgs = @($ServerPath, "--host", $HostAddress, "--port", $Port)
+}
+
+$localUrl = "http://127.0.0.1:$Port/register-pilot.html"
+
+Write-Host ""
+Write-Host "GroundMesh registration pilot launch"
+Write-Host "Local URL: $localUrl"
+
+if ($AllowLan) {
+  $getNetIp = Get-Command Get-NetIPAddress -ErrorAction SilentlyContinue
+  if ($getNetIp) {
+    $lanIps = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+      Where-Object {
+        $_.IPAddress -notlike '127.*' -and
+        $_.IPAddress -notlike '169.254.*' -and
+        $_.InterfaceAlias -notmatch 'Loopback|vEthernet|WSL|Hyper-V|Teredo|Bluetooth|Virtual'
+      } |
+      Select-Object -ExpandProperty IPAddress -Unique
+  } else {
+    $lanIps = @()
+  }
+
+  if ($lanIps) {
+    Write-Host "LAN access enabled. Share only with invited-circle participants."
+    foreach ($ip in $lanIps) {
+      Write-Host ("Share URL: http://{0}:{1}/register-pilot.html" -f $ip, $Port)
+    }
+  } else {
+    Write-Host "LAN access was requested, but no suitable IPv4 address was detected."
+  }
+
+  Write-Host "If Windows asks about firewall access, allow Private networks only."
 }
 
 if ($OpenBrowser) {
-  Start-Process "http://127.0.0.1:$Port/register-pilot.html"
+  Start-Process $localUrl
 }
 
 & $pythonExe @pythonArgs


### PR DESCRIPTION
## Why
The first self-registration and record review are done, so the next smallest real move is letting Mirko test the invited-circle pilot from another nearby device without jumping straight to a broad internet-facing intake.

## What Changed
- extend `scripts/start-registration-pilot.ps1` with `-AllowLan`
- when LAN mode is used, bind the pilot server to `0.0.0.0`
- print the local URL plus detected LAN share URLs for the current network
- remind the steward to allow Private networks only if Windows shows a firewall prompt

## Validation
- `scripts/health-check.ps1` -> `Live OK: 13  Live BAD: 0` and `Files OK: 16  Files MISS: 0`
- local LAN dry run via `Start-Job`:
  - launcher printed the local URL and a share URL like `http://192.168.1.13:8787/register-pilot.html`
  - `GET http://127.0.0.1:8787/api/pilot-register/health` returned active
- existing self-registration artifacts remain present locally in the private pilot workspace

## Scope Guardrail
This is still invited-circle pilot work. It enables nearby-device testing on Mirko's network; it does not yet create a broad internet registration service.