### PR TITLE
pilot: guard against duplicate server launches

### DIFF
--- a/scripts/start-registration-pilot.ps1
+++ b/scripts/start-registration-pilot.ps1
@@ -7,9 +7,33 @@ param(
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 $ServerPath = Join-Path $RepoRoot "tools/registration_pilot_server.py"
 $HostAddress = if ($AllowLan) { "0.0.0.0" } else { "127.0.0.1" }
+$localUrl = "http://127.0.0.1:$Port/register-pilot.html"
 
 if (!(Test-Path $ServerPath)) {
   throw "Registration pilot server not found: $ServerPath"
+}
+
+$existingPilotProcesses = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+  Where-Object {
+    $_.Name -eq 'python.exe' -and
+    $_.CommandLine -match 'registration_pilot_server\.py'
+  } |
+  Sort-Object ProcessId
+
+if ($existingPilotProcesses) {
+  Write-Host ""
+  Write-Host "GroundMesh registration pilot is already running."
+  foreach ($proc in $existingPilotProcesses) {
+    Write-Host ("Existing PID {0}: {1}" -f $proc.ProcessId, $proc.CommandLine)
+  }
+  Write-Host "Use .\\scripts\\stop-registration-pilot.ps1 first if you want a clean restart."
+  Write-Host "Local URL: $localUrl"
+
+  if ($OpenBrowser) {
+    Start-Process $localUrl
+  }
+
+  return
 }
 
 $python = Get-Command python -ErrorAction SilentlyContinue
@@ -25,8 +49,6 @@ if (-not $python) {
   $pythonExe = $python.Source
   $pythonArgs = @($ServerPath, "--host", $HostAddress, "--port", $Port)
 }
-
-$localUrl = "http://127.0.0.1:$Port/register-pilot.html"
 
 Write-Host ""
 Write-Host "GroundMesh registration pilot launch"

--- a/scripts/stop-registration-pilot.ps1
+++ b/scripts/stop-registration-pilot.ps1
@@ -1,0 +1,20 @@
+$pilotProcesses = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+  Where-Object {
+    $_.Name -eq 'python.exe' -and
+    $_.CommandLine -match 'registration_pilot_server\.py'
+  } |
+  Sort-Object ProcessId
+
+if (-not $pilotProcesses) {
+  Write-Host "No GroundMesh registration pilot server is currently running."
+  return
+}
+
+foreach ($proc in $pilotProcesses) {
+  try {
+    Stop-Process -Id $proc.ProcessId -Force -ErrorAction Stop
+    Write-Host ("Stopped registration pilot PID {0}" -f $proc.ProcessId)
+  } catch {
+    Write-Host ("Could not stop registration pilot PID {0}: {1}" -f $proc.ProcessId, $_.Exception.Message)
+  }
+}


### PR DESCRIPTION
## Why
The first self-registration and LAN pilot launch surfaced a practical issue: running the launcher multiple times could leave extra blank PowerShell/python windows around and create multiple pilot server processes on the same machine.

## What Changed
- update `scripts/start-registration-pilot.ps1` to detect an already-running registration pilot server and reuse it instead of launching more duplicates
- add `scripts/stop-registration-pilot.ps1` for one-command cleanup of pilot server processes
- keep the local URL visible when the launcher exits early because a pilot server is already active

## Validation
- running `scripts/start-registration-pilot.ps1 -AllowLan` while pilot servers were already active now prints the existing PIDs and exits cleanly instead of opening more duplicate windows
- existing pilot processes remained detectable at PIDs like `2264` and `8588`
- the public docs health check was already green before this change and this batch only affects local pilot scripts

## Scope Guardrail
This is local pilot operational cleanup only. It reduces process confusion and does not widen the registration surface.