### PR TITLE
Add PWA readiness, runtime boundary, and one-loop docs and wire into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ start .\docs\atlas\index.html
 - Contact: [docs/contact.html](docs/contact.html)
 - Privacy: [docs/privacy.html](docs/privacy.html)
 - Landscape scan: [docs/landscape.html](docs/landscape.html)
+- PWA readiness note: [docs/PWA_READINESS.md](docs/PWA_READINESS.md)
+- Runtime boundary map: [docs/RUNTIME_BOUNDARY.md](docs/RUNTIME_BOUNDARY.md)
+- One-loop breathing test: [docs/ONE_LOOP.md](docs/ONE_LOOP.md)
 
 ## Working pattern
 

--- a/docs/ONE_LOOP.md
+++ b/docs/ONE_LOOP.md
@@ -1,0 +1,46 @@
+# One Tiny End-to-End Loop (GroundMesh Breathing Test)
+
+## Goal
+
+Prove GroundMesh is operationally alive with one harmless, bounded assignment cycle from publish to visible result.
+
+## Loop definition
+
+1. **Seed publishes one public assignment envelope**
+   - Envelope includes: task id, allowed action, timeout, expected output schema.
+2. **One light node fetches assignment**
+   - Node records fetch time and envelope id.
+3. **Node writes receipt to local inbox**
+   - Creates immutable local record before execution.
+4. **Node performs one bounded harmless task**
+   - Example: fetch a public status file, transform into a normalized summary.
+5. **Node writes result to outbox**
+   - Include result payload, execution metadata, and checksum.
+6. **Result is validated and shown in public view**
+   - Validation checks schema and envelope match.
+   - Public page shows task id, node id alias, timestamp, status.
+
+## Constraints
+
+- No privileged machine actions.
+- No credential-required endpoints.
+- No side effects outside local scratch/output paths.
+- Clear timeout and retry behavior.
+
+## Minimum artifacts
+
+- Assignment envelope schema.
+- Inbox/outbox file formats.
+- Result validator script.
+- Public status renderer (static snapshot or generated JSON view).
+
+## Success criteria
+
+- Same envelope can be processed repeatably without ambiguity.
+- Validation fails safely on malformed results.
+- Public view updates only from validated outputs.
+- Full loop can run from clean state with one command sequence.
+
+## Why this matters
+
+This loop prevents architecture drift. It forces contracts, observability, and trust posture to be exercised by runnable reality before adding complexity.

--- a/docs/PWA_READINESS.md
+++ b/docs/PWA_READINESS.md
@@ -1,0 +1,75 @@
+# PWA Readiness Note
+
+## Purpose
+
+This note defines the minimum viable PWA posture for the GroundMesh public front door on GitHub Pages.
+
+Ground rule: the PWA is a universal access layer, not the full GroundMesh runtime.
+
+## What the PWA should provide now
+
+- Installable public front door across modern mobile and desktop browsers.
+- Fast repeat visits through cached static assets.
+- Basic offline readability for key orientation pages.
+- Honest network-state signaling when dynamic data cannot load.
+
+## Required pieces
+
+1. **Web app manifest**
+   - Name, short name, icons, theme/background colors, display mode, start URL, scope.
+2. **Service worker**
+   - Cache static shell and core pages.
+   - Use a safe cache strategy (cache-first for immutable assets, network-first for live status).
+3. **HTTPS hosting**
+   - Satisfied by GitHub Pages.
+4. **Install and fallback UX**
+   - Clear install affordance where browser supports it.
+   - Clear fallback for browsers that do not expose install prompts.
+
+## Cache boundaries
+
+Safe to cache aggressively:
+
+- Static HTML/CSS/JS assets.
+- Public non-sensitive docs and glossary content.
+
+Cache cautiously (short TTL or network-first):
+
+- Status dashboards and registry snapshots.
+- Any data that indicates current network health.
+
+Never treat as offline-authoritative:
+
+- Operational truths that require current trust-state validation.
+- Any sensitive or privileged control data.
+
+## GitHub Pages fit
+
+GitHub Pages is appropriate for:
+
+- Public front door.
+- Public orientation docs.
+- Installable PWA shell.
+
+GitHub Pages is not the place for:
+
+- Secret storage.
+- Private write APIs.
+- Long-running coordination jobs.
+- Trusted signing workflows.
+
+## Relationship to node agents
+
+- PWA: discover, read, orient, lightweight interaction.
+- Node agent: execute bounded tasks, maintain durable participation, handle signed/verified flows.
+
+The PWA can visualize mesh state and submit low-risk public input, while node agents carry durable participation responsibilities.
+
+## Readiness checklist
+
+- [ ] Manifest is complete and versioned.
+- [ ] Service worker scope is explicit and tested.
+- [ ] Offline mode shows accurate capability limits.
+- [ ] Dynamic views degrade gracefully when offline.
+- [ ] Public/private boundary is documented and enforced.
+- [ ] Cache invalidation strategy is documented.

--- a/docs/RUNTIME_BOUNDARY.md
+++ b/docs/RUNTIME_BOUNDARY.md
@@ -1,0 +1,63 @@
+# Runtime Boundary: Public Pages vs Live Services
+
+## Why this exists
+
+GroundMesh uses GitHub Pages as a transparent public front door. That is a strength, but only if the runtime boundary stays explicit.
+
+This document defines what belongs in static public hosting and what must run in dedicated services or node agents.
+
+## Public static layer (GitHub Pages)
+
+Use for:
+
+- Public narrative and orientation pages.
+- Atlas and documentation artifacts.
+- Public checklists and governance references.
+- PWA shell, static assets, and non-sensitive read-only views.
+
+Characteristics:
+
+- Deterministic, inspectable, low operational risk.
+- No private secrets.
+- No server-side compute.
+
+## Live service / node layer (outside Pages)
+
+Use for:
+
+- Assignment distribution and result collection.
+- Durable job execution and scheduling.
+- Trust-sensitive verification/signing workflows.
+- Any write operation requiring integrity controls.
+- Any API that could expose sensitive metadata.
+
+Characteristics:
+
+- Requires authentication and authorization design.
+- Requires observability, alerting, and incident handling.
+- Must handle abuse resistance and rate controls.
+
+## Non-negotiable controls
+
+- Never store credentials or private keys in the static site.
+- Never assume client-side code can protect secrets.
+- Treat browser storage as user convenience, not secure state.
+- Validate and sanitize every input at live service boundaries.
+- Keep public and privileged command paths separate by design.
+
+## Data classification quick map
+
+- **Public**: docs, static maps, openly published status snapshots.
+- **Operational**: queue states, assignment receipts, node health records.
+- **Sensitive**: secrets, private contacts, trust anchors, privileged controls.
+
+Only the first class should exist in GitHub Pages artifacts.
+
+## Evolution rule
+
+Start centralized for safety and clarity, then decentralize intentionally:
+
+1. Public documentation and transparency first.
+2. Minimal live loop with bounded tasks.
+3. Hardened verification and trust services.
+4. Federated participation as operational maturity proves out.


### PR DESCRIPTION
### Motivation

- Clarify the public/static vs live/runtime separation for GroundMesh to reduce accidental leakage of secrets or server-side expectations. 
- Provide a minimal PWA readiness note so the GitHub Pages front door can be installable and cache-safe without conflating runtime responsibilities. 
- Introduce a small end-to-end "one-loop" breathing test to force a repeatable, harmless exercise of assignment, execution, validation, and public display to keep contracts runnable. 

### Description

- Add `docs/PWA_READINESS.md` documenting required manifest, service worker caching strategy, GitHub Pages fit, and a readiness checklist. 
- Add `docs/RUNTIME_BOUNDARY.md` defining what belongs on static public pages vs what must run in live services or node agents and a data classification map. 
- Add `docs/ONE_LOOP.md` specifying a bounded end-to-end loop (envelope, inbox/outbox, execution, validation, public view) with constraints and success criteria. 
- Update `README.md` to link the new PWA, runtime boundary, and one-loop documents from the "Best next pages" section. 

### Testing

- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dddefcc3788327ab0c1759ec6e0c38)