### PR TITLE
docs: anchor Behavior Atlas evidence-first pilot

### DIFF
--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -178,11 +178,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>27</strong>
+          <strong>30</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>27</strong>
+          <strong>30</strong>
         </div>
       </div>
     </section>
@@ -257,6 +257,14 @@
   <td>Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates.</td>
 </tr>
             <tr>
+  <td><a class="id-link" href="../decisions/0006-behavior-atlas-evidence-pilot.md">ADR-0006</a></td>
+  <td><strong>Behavior Atlas Begins as an Evidence-First Pilot</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0006-behavior-atlas-evidence-pilot.md</code></td>
+  <td>Establishes the Behavior Atlas as an evidence-first, human-reviewed pilot that maps claims and patterns without person scoring or autonomous publication.</td>
+</tr>
+            <tr>
   <td><a class="id-link" href="../checklists/Registration_Interest_Triage_Checklist.md">CHECKLIST-REGISTRATION-INTEREST-TRIAGE</a></td>
   <td><strong>Registration Interest Triage Checklist</strong></td>
   <td><span class="chip">checklist</span></td>
@@ -303,6 +311,22 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/invariants/GM-INV-VIII.md</code></td>
   <td>Sustained participation must arise from voluntary re-engagement, not compulsion. Systems must preserve agency, rhythm, and the right to pause without loss of dignity.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="seed-trust-mesh-edge.md">GUIDE-ARCH-SEED-TRUST-MESH-EDGE</a></td>
+  <td><strong>GroundMesh Architecture: Seed / Trust / Mesh / Edge</strong></td>
+  <td><span class="chip">guide</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/atlas/seed-trust-mesh-edge.md</code></td>
+  <td>Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="light-node-agent-contract.md">GUIDE-LIGHT-NODE-CONTRACT</a></td>
+  <td><strong>GroundMesh Light Node Agent Contract v1</strong></td>
+  <td><span class="chip">guide</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/atlas/light-node-agent-contract.md</code></td>
+  <td>Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="groundmesh-new-chat-handoff.md">GUIDE-NEW-CHAT-HANDOFF</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -49,6 +49,14 @@
       "summary": "Establishes the Behavior Atlas as an evidence-first, human-reviewed pilot that maps claims and patterns without person scoring or autonomous publication."
     },
     {
+      "id": "CHECKLIST-REGISTRATION-PILOT",
+      "name": "Registration Pilot Readiness Checklist",
+      "type": "checklist",
+      "status": "active",
+      "path": "docs/checklists/Registration_Pilot_Readiness_Checklist.md",
+      "summary": "Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact."
+    },
+    {
       "id": "CHECKLIST-REGISTRATION-INTEREST-TRIAGE",
       "name": "Registration Interest Triage Checklist",
       "type": "checklist",
@@ -57,12 +65,44 @@
       "summary": "Smallest honest handling checklist for public registration-interest emails before any real pilot intake is open."
     },
     {
-      "id": "CHECKLIST-REGISTRATION-PILOT",
-      "name": "Registration Pilot Readiness Checklist",
-      "type": "checklist",
+      "id": "NOTE-SESSION-0001",
+      "name": "Codex Session 0001: First Contact and Working Basis",
+      "type": "note",
       "status": "active",
-      "path": "docs/checklists/Registration_Pilot_Readiness_Checklist.md",
-      "summary": "Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact."
+      "path": "docs/atlas/session-0001-codex-first-contact.md",
+      "summary": "Tracked memory of the first major Codex GroundMesh session, including workflow doctrine, public-surface stabilization, and the first real registration pilot outcomes."
+    },
+    {
+      "id": "GUIDE-NEW-CHAT-HANDOFF",
+      "name": "GroundMesh New Chat Handoff",
+      "type": "guide",
+      "status": "active",
+      "path": "docs/atlas/groundmesh-new-chat-handoff.md",
+      "summary": "Compact reload note for starting a new chat without losing the current GroundMesh state or falling into long recap mode."
+    },
+    {
+      "id": "PAGE-REGISTER-PILOT",
+      "name": "GroundMesh Invited-Circle Registration Pilot",
+      "type": "page",
+      "status": "active",
+      "path": "docs/register-pilot.html",
+      "summary": "Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active."
+    },
+    {
+      "id": "TEMPLATE-REGISTRATION-PILOT-SCOPE",
+      "name": "Registration Pilot Scope Canvas",
+      "type": "template",
+      "status": "active",
+      "path": "docs/templates/Registration_Pilot_Scope_Canvas.md",
+      "summary": "Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact."
+    },
+    {
+      "id": "TEMPLATE-REGISTRATION-PILOT-RECORD",
+      "name": "Registration Pilot Record Template",
+      "type": "template",
+      "status": "active",
+      "path": "docs/templates/Registration_Pilot_Record.md",
+      "summary": "Reusable minimal record for one actual participant during the invited-circle registration pilot."
     },
     {
       "id": "DOC-ASSISTANT-BRIEF",
@@ -100,38 +140,6 @@
       ]
     },
     {
-      "id": "GUIDE-ARCH-SEED-TRUST-MESH-EDGE",
-      "name": "GroundMesh Architecture: Seed / Trust / Mesh / Edge",
-      "type": "guide",
-      "status": "active",
-      "path": "docs/atlas/seed-trust-mesh-edge.md",
-      "summary": "Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization."
-    },
-    {
-      "id": "GUIDE-LIGHT-NODE-CONTRACT",
-      "name": "GroundMesh Light Node Agent Contract v1",
-      "type": "guide",
-      "status": "active",
-      "path": "docs/atlas/light-node-agent-contract.md",
-      "summary": "Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract."
-    },
-    {
-      "id": "GUIDE-NEW-CHAT-HANDOFF",
-      "name": "GroundMesh New Chat Handoff",
-      "type": "guide",
-      "status": "active",
-      "path": "docs/atlas/groundmesh-new-chat-handoff.md",
-      "summary": "Compact reload note for starting a new chat without losing the current GroundMesh state or falling into long recap mode."
-    },
-    {
-      "id": "NOTE-SESSION-0001",
-      "name": "Codex Session 0001: First Contact and Working Basis",
-      "type": "note",
-      "status": "active",
-      "path": "docs/atlas/session-0001-codex-first-contact.md",
-      "summary": "Tracked memory of the first major Codex GroundMesh session, including workflow doctrine, public-surface stabilization, and the first real registration pilot outcomes."
-    },
-    {
       "id": "PAGE-COMPUTE",
       "name": "Compute Transparency",
       "type": "page",
@@ -148,12 +156,12 @@
       "summary": "Simple public contact path for questions, corrections, first contact, and participation guidance."
     },
     {
-      "id": "PAGE-CONTRIBUTE",
-      "name": "Contributors Hub",
+      "id": "PAGE-REGISTER",
+      "name": "GroundMesh Registration Status",
       "type": "page",
       "status": "active",
-      "path": "docs/contribute.html",
-      "summary": "Primary public on-ramp for volunteers, issue filing, and low-friction participation."
+      "path": "docs/register.html",
+      "summary": "Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot."
     },
     {
       "id": "PAGE-GET-STARTED",
@@ -180,14 +188,6 @@
       "summary": "Broad scan of live pages, local repos, mirrors, and adjacent web surfaces around GroundMesh."
     },
     {
-      "id": "PAGE-MAP",
-      "name": "GroundMesh Map",
-      "type": "page",
-      "status": "active",
-      "path": "docs/map.html",
-      "summary": "Public-facing orientation page for the project landscape and navigation."
-    },
-    {
       "id": "PAGE-PRIVACY",
       "name": "GroundMesh Privacy",
       "type": "page",
@@ -196,20 +196,20 @@
       "summary": "Plain-language statement of the current public privacy posture, limits, and data-minimization rule."
     },
     {
-      "id": "PAGE-REGISTER",
-      "name": "GroundMesh Registration Status",
+      "id": "PAGE-CONTRIBUTE",
+      "name": "Contributors Hub",
       "type": "page",
       "status": "active",
-      "path": "docs/register.html",
-      "summary": "Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot."
+      "path": "docs/contribute.html",
+      "summary": "Primary public on-ramp for volunteers, issue filing, and low-friction participation."
     },
     {
-      "id": "PAGE-REGISTER-PILOT",
-      "name": "GroundMesh Invited-Circle Registration Pilot",
+      "id": "PAGE-MAP",
+      "name": "GroundMesh Map",
       "type": "page",
       "status": "active",
-      "path": "docs/register-pilot.html",
-      "summary": "Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active."
+      "path": "docs/map.html",
+      "summary": "Public-facing orientation page for the project landscape and navigation."
     },
     {
       "id": "STATUS-PUBLIC",
@@ -218,22 +218,6 @@
       "status": "active",
       "path": "docs/data/status.json",
       "summary": "Tracks public health notes for the current docs surface and Atlas-backed pages."
-    },
-    {
-      "id": "TEMPLATE-REGISTRATION-PILOT-RECORD",
-      "name": "Registration Pilot Record Template",
-      "type": "template",
-      "status": "active",
-      "path": "docs/templates/Registration_Pilot_Record.md",
-      "summary": "Reusable minimal record for one actual participant during the invited-circle registration pilot."
-    },
-    {
-      "id": "TEMPLATE-REGISTRATION-PILOT-SCOPE",
-      "name": "Registration Pilot Scope Canvas",
-      "type": "template",
-      "status": "active",
-      "path": "docs/templates/Registration_Pilot_Scope_Canvas.md",
-      "summary": "Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact."
     },
     {
       "id": "TP-03",
@@ -245,6 +229,22 @@
       "related": [
         "GM-INV-VIII"
       ]
+    },
+    {
+      "id": "GUIDE-ARCH-SEED-TRUST-MESH-EDGE",
+      "name": "GroundMesh Architecture: Seed / Trust / Mesh / Edge",
+      "type": "guide",
+      "status": "active",
+      "path": "docs/atlas/seed-trust-mesh-edge.md",
+      "summary": "Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization."
+    },
+    {
+      "id": "GUIDE-LIGHT-NODE-CONTRACT",
+      "name": "GroundMesh Light Node Agent Contract v1",
+      "type": "guide",
+      "status": "active",
+      "path": "docs/atlas/light-node-agent-contract.md",
+      "summary": "Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract."
     }
   ]
 }

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -41,12 +41,12 @@
       "summary": "Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates."
     },
     {
-      "id": "CHECKLIST-REGISTRATION-PILOT",
-      "name": "Registration Pilot Readiness Checklist",
-      "type": "checklist",
+      "id": "ADR-0006",
+      "name": "Behavior Atlas Begins as an Evidence-First Pilot",
+      "type": "decision",
       "status": "active",
-      "path": "docs/checklists/Registration_Pilot_Readiness_Checklist.md",
-      "summary": "Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact."
+      "path": "docs/decisions/0006-behavior-atlas-evidence-pilot.md",
+      "summary": "Establishes the Behavior Atlas as an evidence-first, human-reviewed pilot that maps claims and patterns without person scoring or autonomous publication."
     },
     {
       "id": "CHECKLIST-REGISTRATION-INTEREST-TRIAGE",
@@ -57,44 +57,12 @@
       "summary": "Smallest honest handling checklist for public registration-interest emails before any real pilot intake is open."
     },
     {
-      "id": "NOTE-SESSION-0001",
-      "name": "Codex Session 0001: First Contact and Working Basis",
-      "type": "note",
+      "id": "CHECKLIST-REGISTRATION-PILOT",
+      "name": "Registration Pilot Readiness Checklist",
+      "type": "checklist",
       "status": "active",
-      "path": "docs/atlas/session-0001-codex-first-contact.md",
-      "summary": "Tracked memory of the first major Codex GroundMesh session, including workflow doctrine, public-surface stabilization, and the first real registration pilot outcomes."
-    },
-    {
-      "id": "GUIDE-NEW-CHAT-HANDOFF",
-      "name": "GroundMesh New Chat Handoff",
-      "type": "guide",
-      "status": "active",
-      "path": "docs/atlas/groundmesh-new-chat-handoff.md",
-      "summary": "Compact reload note for starting a new chat without losing the current GroundMesh state or falling into long recap mode."
-    },
-    {
-      "id": "PAGE-REGISTER-PILOT",
-      "name": "GroundMesh Invited-Circle Registration Pilot",
-      "type": "page",
-      "status": "active",
-      "path": "docs/register-pilot.html",
-      "summary": "Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active."
-    },
-    {
-      "id": "TEMPLATE-REGISTRATION-PILOT-SCOPE",
-      "name": "Registration Pilot Scope Canvas",
-      "type": "template",
-      "status": "active",
-      "path": "docs/templates/Registration_Pilot_Scope_Canvas.md",
-      "summary": "Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact."
-    },
-    {
-      "id": "TEMPLATE-REGISTRATION-PILOT-RECORD",
-      "name": "Registration Pilot Record Template",
-      "type": "template",
-      "status": "active",
-      "path": "docs/templates/Registration_Pilot_Record.md",
-      "summary": "Reusable minimal record for one actual participant during the invited-circle registration pilot."
+      "path": "docs/checklists/Registration_Pilot_Readiness_Checklist.md",
+      "summary": "Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact."
     },
     {
       "id": "DOC-ASSISTANT-BRIEF",
@@ -132,6 +100,38 @@
       ]
     },
     {
+      "id": "GUIDE-ARCH-SEED-TRUST-MESH-EDGE",
+      "name": "GroundMesh Architecture: Seed / Trust / Mesh / Edge",
+      "type": "guide",
+      "status": "active",
+      "path": "docs/atlas/seed-trust-mesh-edge.md",
+      "summary": "Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization."
+    },
+    {
+      "id": "GUIDE-LIGHT-NODE-CONTRACT",
+      "name": "GroundMesh Light Node Agent Contract v1",
+      "type": "guide",
+      "status": "active",
+      "path": "docs/atlas/light-node-agent-contract.md",
+      "summary": "Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract."
+    },
+    {
+      "id": "GUIDE-NEW-CHAT-HANDOFF",
+      "name": "GroundMesh New Chat Handoff",
+      "type": "guide",
+      "status": "active",
+      "path": "docs/atlas/groundmesh-new-chat-handoff.md",
+      "summary": "Compact reload note for starting a new chat without losing the current GroundMesh state or falling into long recap mode."
+    },
+    {
+      "id": "NOTE-SESSION-0001",
+      "name": "Codex Session 0001: First Contact and Working Basis",
+      "type": "note",
+      "status": "active",
+      "path": "docs/atlas/session-0001-codex-first-contact.md",
+      "summary": "Tracked memory of the first major Codex GroundMesh session, including workflow doctrine, public-surface stabilization, and the first real registration pilot outcomes."
+    },
+    {
       "id": "PAGE-COMPUTE",
       "name": "Compute Transparency",
       "type": "page",
@@ -148,12 +148,12 @@
       "summary": "Simple public contact path for questions, corrections, first contact, and participation guidance."
     },
     {
-      "id": "PAGE-REGISTER",
-      "name": "GroundMesh Registration Status",
+      "id": "PAGE-CONTRIBUTE",
+      "name": "Contributors Hub",
       "type": "page",
       "status": "active",
-      "path": "docs/register.html",
-      "summary": "Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot."
+      "path": "docs/contribute.html",
+      "summary": "Primary public on-ramp for volunteers, issue filing, and low-friction participation."
     },
     {
       "id": "PAGE-GET-STARTED",
@@ -180,22 +180,6 @@
       "summary": "Broad scan of live pages, local repos, mirrors, and adjacent web surfaces around GroundMesh."
     },
     {
-      "id": "PAGE-PRIVACY",
-      "name": "GroundMesh Privacy",
-      "type": "page",
-      "status": "active",
-      "path": "docs/privacy.html",
-      "summary": "Plain-language statement of the current public privacy posture, limits, and data-minimization rule."
-    },
-    {
-      "id": "PAGE-CONTRIBUTE",
-      "name": "Contributors Hub",
-      "type": "page",
-      "status": "active",
-      "path": "docs/contribute.html",
-      "summary": "Primary public on-ramp for volunteers, issue filing, and low-friction participation."
-    },
-    {
       "id": "PAGE-MAP",
       "name": "GroundMesh Map",
       "type": "page",
@@ -204,12 +188,52 @@
       "summary": "Public-facing orientation page for the project landscape and navigation."
     },
     {
+      "id": "PAGE-PRIVACY",
+      "name": "GroundMesh Privacy",
+      "type": "page",
+      "status": "active",
+      "path": "docs/privacy.html",
+      "summary": "Plain-language statement of the current public privacy posture, limits, and data-minimization rule."
+    },
+    {
+      "id": "PAGE-REGISTER",
+      "name": "GroundMesh Registration Status",
+      "type": "page",
+      "status": "active",
+      "path": "docs/register.html",
+      "summary": "Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot."
+    },
+    {
+      "id": "PAGE-REGISTER-PILOT",
+      "name": "GroundMesh Invited-Circle Registration Pilot",
+      "type": "page",
+      "status": "active",
+      "path": "docs/register-pilot.html",
+      "summary": "Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active."
+    },
+    {
       "id": "STATUS-PUBLIC",
       "name": "Public Status Snapshot",
       "type": "data",
       "status": "active",
       "path": "docs/data/status.json",
       "summary": "Tracks public health notes for the current docs surface and Atlas-backed pages."
+    },
+    {
+      "id": "TEMPLATE-REGISTRATION-PILOT-RECORD",
+      "name": "Registration Pilot Record Template",
+      "type": "template",
+      "status": "active",
+      "path": "docs/templates/Registration_Pilot_Record.md",
+      "summary": "Reusable minimal record for one actual participant during the invited-circle registration pilot."
+    },
+    {
+      "id": "TEMPLATE-REGISTRATION-PILOT-SCOPE",
+      "name": "Registration Pilot Scope Canvas",
+      "type": "template",
+      "status": "active",
+      "path": "docs/templates/Registration_Pilot_Scope_Canvas.md",
+      "summary": "Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact."
     },
     {
       "id": "TP-03",
@@ -221,22 +245,6 @@
       "related": [
         "GM-INV-VIII"
       ]
-    },
-    {
-      "id": "GUIDE-ARCH-SEED-TRUST-MESH-EDGE",
-      "name": "GroundMesh Architecture: Seed / Trust / Mesh / Edge",
-      "type": "guide",
-      "status": "active",
-      "path": "docs/atlas/seed-trust-mesh-edge.md",
-      "summary": "Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization."
-    },
-    {
-      "id": "GUIDE-LIGHT-NODE-CONTRACT",
-      "name": "GroundMesh Light Node Agent Contract v1",
-      "type": "guide",
-      "status": "active",
-      "path": "docs/atlas/light-node-agent-contract.md",
-      "summary": "Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract."
     }
   ]
 }

--- a/docs/decisions/0006-behavior-atlas-evidence-pilot.md
+++ b/docs/decisions/0006-behavior-atlas-evidence-pilot.md
@@ -1,0 +1,121 @@
+# 0006 — Behavior Atlas Begins as an Evidence-First Pilot
+Date: 2026-07-22
+Status: Accepted
+
+## Context
+
+GroundMesh has long aimed to make patterns of extraction, cooperation, concentration, stewardship,
+and shared benefit easier to see through public evidence. The next phase is the **Behavior Atlas**:
+a readable evidence map that can connect public records, audits, procurement, ownership,
+environmental data, rigorous journalism, and other inspectable sources.
+
+This creates real risks if interpretation outruns evidence. A behavior map could become a hidden
+reputation system, collapse a person into a label, conceal uncertainty behind a score, or automate
+publication before correction and review paths exist. It could also be confused with **Project
+Atlas**, whose existing purpose is to inventory GroundMesh artifacts and show repository health.
+
+The current GroundMesh public layer is static, versioned, and intentionally honest about its
+privacy limits. The Behavior Atlas should begin inside those limits rather than pretending that a
+hardened research, intake, or adjudication system already exists.
+
+## Decision
+
+GroundMesh will begin the Behavior Atlas as a narrow, evidence-first pilot.
+
+1. **Project Atlas and the Behavior Atlas remain distinct.**
+   - Project Atlas continues to map what exists in the GroundMesh repository and its health.
+   - The Behavior Atlas maps public evidence, claims, observable conduct, consequences, and
+     cautiously stated patterns.
+
+2. **The unit of analysis is an evidenced action or system footprint, not a moral identity.**
+   - Primary subjects are projects, institutions, public programs, policies, contracts, and events.
+   - A person may appear only when a relevant public role is necessary to understand an evidenced
+     action.
+   - The pilot will not create person scores, moral rankings, guilt findings, inferred motives, or
+     permanent labels.
+
+3. **The evidence chain must remain inspectable.**
+   - The core chain is: source → evidence item → atomic claim → pattern assessment → case.
+   - Every public claim must resolve to identifiable sources and an exact locator.
+   - Fact, allegation, inference, and pattern assessment must remain visibly distinct.
+   - Contradictory and exculpatory evidence are first-class records, not footnotes to be hidden.
+
+4. **Interpretation must expose its limits.**
+   - Pattern assessments may use transparent lenses such as consent and agency, distribution of
+     benefits and burdens, transparency and answerability, resource stewardship, reciprocity and
+     cooperation, and concentration or capture risk.
+   - Direction may be described as cooperation-supporting, extraction-risk, mixed, or unclear.
+   - Confidence uses named bands and explicit rationale, not false-precision percentages.
+
+5. **Humans remain responsible for publication.**
+   - Computer Intelligence may help collect metadata, detect duplicates, propose atomic claims,
+     and flag possible contradictions.
+   - It may not assign motive, resolve a contested claim, create a public score, or publish without
+     human approval.
+   - Each release must be reviewable, date-stamped, reproducible, reversible, and preserved in
+     version history.
+
+6. **The first pilot uses public sources only.**
+   - No confidential disclosures, sensitive personal data, anonymous accusations, or emergency
+     reporting enter the static public repository.
+   - Tips, posts, and unverified assertions may be treated only as leads until independently
+     verified.
+   - Data minimization and the existing GroundMesh privacy posture apply throughout.
+
+7. **Correction and rollback precede public scale.**
+   - A public preview requires visible provenance, limitations, counterevidence, review history,
+     a correction path, a review-due date, and a way to supersede a record without erasing history.
+   - If a release causes unresolved harm, loses its evidence trail, or fails validation, the static
+     output can be withdrawn and restored to the last known-good version while the review record
+     remains visible.
+
+8. **The Cooperation Index remains research-only.**
+   - GroundMesh will not publish a composite index until several cases have passed public-alpha
+     review and the methodology has received independent scrutiny.
+   - Early work must first prove that claim-level evidence and corrections remain understandable.
+
+## Guarded rollout
+
+The rollout proceeds through explicit gates:
+
+- **M0 — constitutional anchor:** this ADR, shared terms, prohibited uses, and rollback ownership.
+- **M1 — schema sandbox:** one versioned schema, one synthetic fixture, and one validator; no real
+  subject data and no public route.
+- **M2 — internal case:** one institutional or project case with atomic claims, counterevidence,
+  limitations, and a complete reviewer log.
+- **M3 — unlisted preview:** one accessible static case page with source trails, corrections, and a
+  visible single-reviewer warning when plural review is unavailable.
+- **M4 — public alpha:** several cases, a changelog, expiry policy, privacy and harm review, and a
+  successful restore drill.
+- **M5 — assisted monitoring:** read-only watchers may propose diffs; humans still approve every
+  public release.
+
+## Immediate implementation boundary
+
+This first guarded batch adds only:
+
+- this decision record
+- its Project Atlas registry entry
+- the regenerated Atlas page
+
+It does **not** add a Behavior Atlas page, database, API, scraper, real-subject dataset, score,
+watcher, or automated publisher.
+
+## Consequences
+
+- GroundMesh gains a durable constitutional boundary before it gains new data machinery.
+- The Behavior Atlas can grow from evidence and correction practices rather than from labels.
+- Early progress will be slower than automated bulk collection, but easier to inspect, reverse,
+  and trust.
+- Project Atlas remains the canonical orientation map and records each durable Behavior Atlas
+  artifact as it is accepted.
+- Future schema or interface work requires a separate guarded batch and must pass the applicable
+  rollout gate.
+
+## Related GroundMesh artifacts
+
+- `docs/decisions/0001-why-atlas.md`
+- `docs/decisions/0004-active-dev-promotion-model.md`
+- `docs/atlas/seed-trust-mesh-edge.md`
+- `docs/privacy.html`
+- `docs/assistant-brief.md`


### PR DESCRIPTION
## What changed

- add ADR-0006, **Behavior Atlas Begins as an Evidence-First Pilot**
- register the decision in `docs/atlas/registry.json`
- regenerate `docs/atlas/index.html`
- restore two already-registered architecture guides that were missing from the stale generated page

## Why

The Behavior Atlas needs a durable boundary before schema, data, scoring, or automation work begins. This decision makes it an evidence-first, human-reviewed system for observable actions and system footprints—not a person-ranking or autonomous publication system.

## Impact

This batch adds no Behavior Atlas page, database, API, scraper, real-subject dataset, score, watcher, or automated publisher. Project Atlas remains the repository inventory and health map.

## Validation

- pre-change health-file baseline: 16/16 required repository files present on `main`
- branch registry: 30 active entries, 30 unique IDs
- generated Atlas: 30 rows, 30 unique IDs, both counters show 30
- registered-path check: 30/30 paths resolve on the branch
- ADR, registry, and generated page read back exactly
- final diff is limited to the intended three files
