### PR TITLE
behavior-atlas: add M1 schema sandbox

### DIFF
--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -40,6 +40,11 @@ jobs:
           print("JSON OK")
           PY
 
+      - name: Validate Behavior Atlas schema sandbox
+        shell: pwsh
+        run: |
+          ./scripts/behavior-atlas-validate.ps1 -RequireSynthetic
+
       - name: Check links with lychee
         uses: lycheeverse/lychee-action@v1
         with:

--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -178,11 +178,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>30</strong>
+          <strong>31</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>30</strong>
+          <strong>31</strong>
         </div>
       </div>
     </section>
@@ -423,6 +423,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/register-pilot.html</code></td>
   <td>Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../behavior-atlas/schema/v0.1.schema.json">SCHEMA-BEHAVIOR-ATLAS-V0-1</a></td>
+  <td><strong>Behavior Atlas Schema Sandbox v0.1</strong></td>
+  <td><span class="chip">schema</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/behavior-atlas/schema/v0.1.schema.json</code></td>
+  <td>Experimental M1 contract for synthetic, public-source case bundles, paired with a fictional fixture and semantic validator; forbids person subjects, scores, rankings, inferred motives, and autonomous publication.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../data/status.json">STATUS-PUBLIC</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -49,6 +49,14 @@
       "summary": "Establishes the Behavior Atlas as an evidence-first, human-reviewed pilot that maps claims and patterns without person scoring or autonomous publication."
     },
     {
+      "id": "SCHEMA-BEHAVIOR-ATLAS-V0-1",
+      "name": "Behavior Atlas Schema Sandbox v0.1",
+      "type": "schema",
+      "status": "active",
+      "path": "docs/behavior-atlas/schema/v0.1.schema.json",
+      "summary": "Experimental M1 contract for synthetic, public-source case bundles, paired with a fictional fixture and semantic validator; forbids person subjects, scores, rankings, inferred motives, and autonomous publication."
+    },
+    {
       "id": "CHECKLIST-REGISTRATION-PILOT",
       "name": "Registration Pilot Readiness Checklist",
       "type": "checklist",

--- a/docs/behavior-atlas/examples/synthetic-case.json
+++ b/docs/behavior-atlas/examples/synthetic-case.json
@@ -1,0 +1,332 @@
+{
+  "schema_version": "0.1",
+  "case": {
+    "case_id": "case-synthetic-harbor-shade",
+    "title": "Synthetic Harbor Shade Retrofit",
+    "scope_question": "Did the fictional Harbor Shade Retrofit show cooperation-supporting transparency and distribution patterns while leaving any evidenced access gaps?",
+    "status": "internal_review",
+    "is_synthetic": true,
+    "subject_ids": [
+      "subject-synthetic-harbor-shade"
+    ],
+    "temporal_scope": {
+      "start": "2026-01-01",
+      "end": "2026-06-30"
+    },
+    "geographic_scope": [
+      "Fictional Bay Municipality"
+    ],
+    "limitations": [
+      "This fixture is entirely fictional and exists only to test the M1 schema and validator.",
+      "The example.invalid source URLs do not resolve and must never be presented as real evidence.",
+      "The small claim set is not sufficient for a public Cooperation Index or a real-world conclusion."
+    ],
+    "correction_path": null,
+    "release": {
+      "release_id": "release-synthetic-sandbox-001",
+      "created_at": "2026-07-22T17:30:00Z",
+      "created_by_ref": "reviewer-sandbox-steward",
+      "previous_release_id": null,
+      "public_release": false
+    }
+  },
+  "subjects": [
+    {
+      "subject_id": "subject-synthetic-harbor-shade",
+      "subject_type": "project",
+      "display_name": "Synthetic Harbor Shade Retrofit",
+      "public_role_context": "A fictional municipal heat-mitigation project used only as a non-personal validation fixture.",
+      "jurisdiction": "Fictional Bay Municipality",
+      "temporal_scope": {
+        "start": "2026-01-01",
+        "end": "2026-06-30"
+      },
+      "notes": [
+        "No real institution, contract, official, resident, or place is represented."
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "source_id": "source-synthetic-procurement",
+      "source_class": "A",
+      "source_type": "procurement",
+      "title": "Synthetic Harbor Shade Procurement Notice",
+      "publisher": "Fictional Bay Procurement Office",
+      "url": "https://example.invalid/behavior-atlas/synthetic/procurement-notice",
+      "archive_url": null,
+      "published_at": "2026-01-10",
+      "accessed_at": "2026-07-22T17:30:00Z",
+      "jurisdiction": "Fictional Bay Municipality",
+      "content_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "license_notes": "Synthetic fixture; no external rights or reuse claim.",
+      "handling_notes": "Invented primary-source analogue for schema testing only."
+    },
+    {
+      "source_id": "source-synthetic-audit",
+      "source_class": "A",
+      "source_type": "audit",
+      "title": "Synthetic Harbor Shade Midpoint Audit",
+      "publisher": "Fictional Bay Audit Office",
+      "url": "https://example.invalid/behavior-atlas/synthetic/midpoint-audit",
+      "archive_url": null,
+      "published_at": "2026-06-20",
+      "accessed_at": "2026-07-22T17:30:00Z",
+      "jurisdiction": "Fictional Bay Municipality",
+      "content_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "license_notes": "Synthetic fixture; no external rights or reuse claim.",
+      "handling_notes": "Invented audit analogue for schema testing only."
+    },
+    {
+      "source_id": "source-synthetic-reporting",
+      "source_class": "B",
+      "source_type": "local_reporting",
+      "title": "Synthetic Residents Review the Shade Plan",
+      "publisher": "Fictional Bay Public Ledger",
+      "url": "https://example.invalid/behavior-atlas/synthetic/local-reporting",
+      "archive_url": null,
+      "published_at": "2026-03-15",
+      "accessed_at": "2026-07-22T17:30:00Z",
+      "jurisdiction": "Fictional Bay Municipality",
+      "content_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      "license_notes": "Synthetic fixture; no external rights or reuse claim.",
+      "handling_notes": "Invented secondary-source analogue for schema testing only."
+    }
+  ],
+  "evidence_items": [
+    {
+      "evidence_id": "evidence-synthetic-criteria",
+      "source_id": "source-synthetic-procurement",
+      "locator": "Section 3, evaluation criteria",
+      "observation": "The fictional notice lists evaluation criteria and their relative weights before the submission deadline.",
+      "excerpt": null,
+      "captured_at": "2026-07-22T17:31:00Z",
+      "public_safe": true,
+      "handling_notes": "Paraphrase of invented fixture content; no quotation."
+    },
+    {
+      "evidence_id": "evidence-synthetic-benefit-map",
+      "source_id": "source-synthetic-audit",
+      "locator": "Table 2, neighborhood allocation",
+      "observation": "The fictional audit records that four of six highest-heat blocks received funded shade installations in the first round.",
+      "excerpt": null,
+      "captured_at": "2026-07-22T17:31:00Z",
+      "public_safe": true,
+      "handling_notes": "Paraphrase of invented fixture content; no quotation."
+    },
+    {
+      "evidence_id": "evidence-synthetic-consultation",
+      "source_id": "source-synthetic-reporting",
+      "locator": "Paragraphs 4-6, consultation account",
+      "observation": "The fictional report describes two open resident workshops and identifies three design changes attributed to workshop feedback.",
+      "excerpt": null,
+      "captured_at": "2026-07-22T17:31:00Z",
+      "public_safe": true,
+      "handling_notes": "Paraphrase of invented fixture content; no quotation."
+    },
+    {
+      "evidence_id": "evidence-synthetic-access-gap",
+      "source_id": "source-synthetic-audit",
+      "locator": "Finding 5, notice accessibility",
+      "observation": "The fictional audit records that workshop notices were published online but were not posted at the two community centers serving the least-connected blocks.",
+      "excerpt": null,
+      "captured_at": "2026-07-22T17:31:00Z",
+      "public_safe": true,
+      "handling_notes": "Paraphrase of invented fixture content; no quotation."
+    }
+  ],
+  "claims": [
+    {
+      "claim_id": "claim-synthetic-criteria-published",
+      "statement": "The fictional procurement published weighted evaluation criteria before bids were due.",
+      "claim_kind": "fact",
+      "state": "reviewed",
+      "subject_ids": [
+        "subject-synthetic-harbor-shade"
+      ],
+      "evidence_links": [
+        {
+          "evidence_id": "evidence-synthetic-criteria",
+          "relationship": "supports"
+        }
+      ],
+      "temporal_scope": {
+        "start": "2026-01-10",
+        "end": "2026-01-10"
+      },
+      "place": "Fictional Bay Municipality",
+      "reviewer_refs": [
+        "reviewer-sandbox-steward"
+      ],
+      "review_due": "2026-10-22",
+      "supersedes_claim_id": null
+    },
+    {
+      "claim_id": "claim-synthetic-high-heat-allocation",
+      "statement": "The fictional first funding round reached four of the six blocks identified as having the highest heat exposure.",
+      "claim_kind": "fact",
+      "state": "reviewed",
+      "subject_ids": [
+        "subject-synthetic-harbor-shade"
+      ],
+      "evidence_links": [
+        {
+          "evidence_id": "evidence-synthetic-benefit-map",
+          "relationship": "supports"
+        }
+      ],
+      "temporal_scope": {
+        "start": "2026-01-01",
+        "end": "2026-06-20"
+      },
+      "place": "Fictional Bay Municipality",
+      "reviewer_refs": [
+        "reviewer-sandbox-steward"
+      ],
+      "review_due": "2026-10-22",
+      "supersedes_claim_id": null
+    },
+    {
+      "claim_id": "claim-synthetic-feedback-changes",
+      "statement": "The fictional reporting attributes three design changes to feedback gathered in two open workshops.",
+      "claim_kind": "attributed_allegation",
+      "state": "reviewed",
+      "subject_ids": [
+        "subject-synthetic-harbor-shade"
+      ],
+      "evidence_links": [
+        {
+          "evidence_id": "evidence-synthetic-consultation",
+          "relationship": "supports"
+        }
+      ],
+      "temporal_scope": {
+        "start": "2026-02-01",
+        "end": "2026-03-15"
+      },
+      "place": "Fictional Bay Municipality",
+      "reviewer_refs": [
+        "reviewer-sandbox-steward"
+      ],
+      "review_due": "2026-10-22",
+      "supersedes_claim_id": null
+    },
+    {
+      "claim_id": "claim-synthetic-notice-access-gap",
+      "statement": "The fictional workshop notice process omitted physical postings at two community centers serving the least-connected blocks.",
+      "claim_kind": "fact",
+      "state": "reviewed",
+      "subject_ids": [
+        "subject-synthetic-harbor-shade"
+      ],
+      "evidence_links": [
+        {
+          "evidence_id": "evidence-synthetic-access-gap",
+          "relationship": "supports"
+        }
+      ],
+      "temporal_scope": {
+        "start": "2026-02-01",
+        "end": "2026-03-15"
+      },
+      "place": "Fictional Bay Municipality",
+      "reviewer_refs": [
+        "reviewer-sandbox-steward"
+      ],
+      "review_due": "2026-10-22",
+      "supersedes_claim_id": null
+    }
+  ],
+  "assessments": [
+    {
+      "assessment_id": "assessment-synthetic-transparency",
+      "lens": "transparency_and_answerability",
+      "direction": "cooperation_supporting",
+      "confidence": "emerging",
+      "rationale": "The fictional record shows advance publication of evaluation criteria. The small synthetic source set supports only an emerging assessment, not a broad institutional conclusion.",
+      "supporting_claim_ids": [
+        "claim-synthetic-criteria-published"
+      ],
+      "counter_claim_ids": [],
+      "assessor_refs": [
+        "reviewer-sandbox-steward"
+      ],
+      "assessed_at": "2026-07-22T17:35:00Z",
+      "review_due": "2026-10-22"
+    },
+    {
+      "assessment_id": "assessment-synthetic-consent-access",
+      "lens": "consent_and_agency",
+      "direction": "mixed",
+      "confidence": "emerging",
+      "rationale": "The fictional reporting describes open workshops and feedback-linked changes, while the fictional audit records an access gap in how workshop notices reached less-connected blocks.",
+      "supporting_claim_ids": [
+        "claim-synthetic-feedback-changes"
+      ],
+      "counter_claim_ids": [
+        "claim-synthetic-notice-access-gap"
+      ],
+      "assessor_refs": [
+        "reviewer-sandbox-steward"
+      ],
+      "assessed_at": "2026-07-22T17:35:00Z",
+      "review_due": "2026-10-22"
+    },
+    {
+      "assessment_id": "assessment-synthetic-distribution",
+      "lens": "distribution_of_benefits_and_burdens",
+      "direction": "mixed",
+      "confidence": "emerging",
+      "rationale": "The fictional allocation reached most, but not all, highest-heat blocks. The fixture does not explain why two blocks were deferred, so a stronger direction would exceed the evidence.",
+      "supporting_claim_ids": [
+        "claim-synthetic-high-heat-allocation"
+      ],
+      "counter_claim_ids": [
+        "claim-synthetic-notice-access-gap"
+      ],
+      "assessor_refs": [
+        "reviewer-sandbox-steward"
+      ],
+      "assessed_at": "2026-07-22T17:35:00Z",
+      "review_due": "2026-10-22"
+    }
+  ],
+  "review_events": [
+    {
+      "review_event_id": "review-synthetic-case-created",
+      "target_type": "case",
+      "target_id": "case-synthetic-harbor-shade",
+      "action": "created",
+      "actor_role": "steward",
+      "actor_ref": "reviewer-sandbox-steward",
+      "timestamp": "2026-07-22T17:30:00Z",
+      "reason": "Create a fictional fixture for the M1 schema sandbox.",
+      "changed_fields": [
+        "case",
+        "subjects",
+        "sources",
+        "evidence_items",
+        "claims",
+        "assessments"
+      ],
+      "supersedes_record_id": null
+    },
+    {
+      "review_event_id": "review-synthetic-claims-reviewed",
+      "target_type": "case",
+      "target_id": "case-synthetic-harbor-shade",
+      "action": "reviewed",
+      "actor_role": "reviewer",
+      "actor_ref": "reviewer-sandbox-steward",
+      "timestamp": "2026-07-22T17:40:00Z",
+      "reason": "Confirm that every synthetic claim resolves to an evidence item and that counterevidence remains visible in the mixed assessments.",
+      "changed_fields": [
+        "claims",
+        "assessments",
+        "review_events"
+      ],
+      "supersedes_record_id": null
+    }
+  ],
+  "correction_requests": []
+}

--- a/docs/behavior-atlas/schema/v0.1.schema.json
+++ b/docs/behavior-atlas/schema/v0.1.schema.json
@@ -1,0 +1,966 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mailgmirko-creator.github.io/groundmesh/behavior-atlas/schema/v0.1.schema.json",
+  "title": "GroundMesh Behavior Atlas Case Bundle v0.1",
+  "description": "Experimental M1 schema for evidence-first, human-reviewed, public-source case bundles. It does not permit person subjects, public scores, rankings, inferred motives, or autonomous publication fields.",
+  "type": "object",
+  "propertyNames": {
+    "$ref": "#/$defs/safePropertyName"
+  },
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "case",
+    "subjects",
+    "sources",
+    "evidence_items",
+    "claims",
+    "assessments",
+    "review_events",
+    "correction_requests"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1"
+    },
+    "case": {
+      "$ref": "#/$defs/case"
+    },
+    "subjects": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/subject"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/source"
+      }
+    },
+    "evidence_items": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/evidenceItem"
+      }
+    },
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/claim"
+      }
+    },
+    "assessments": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/assessment"
+      }
+    },
+    "review_events": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/reviewEvent"
+      }
+    },
+    "correction_requests": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/correctionRequest"
+      }
+    }
+  },
+  "$defs": {
+    "safePropertyName": {
+      "type": "string",
+      "not": {
+        "enum": [
+          "score",
+          "rank",
+          "ranking",
+          "person_score",
+          "reputation_score",
+          "moral_label",
+          "guilt_finding",
+          "inferred_motive",
+          "composite_score",
+          "automatic_publication"
+        ]
+      }
+    },
+    "shortText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240
+    },
+    "longText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4000
+    },
+    "dateTime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "timeScope": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "start",
+        "end"
+      ],
+      "properties": {
+        "start": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "end": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        }
+      }
+    },
+    "case": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "title",
+        "scope_question",
+        "status",
+        "is_synthetic",
+        "subject_ids",
+        "temporal_scope",
+        "geographic_scope",
+        "limitations",
+        "correction_path",
+        "release"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "pattern": "^case-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "title": {
+          "$ref": "#/$defs/shortText"
+        },
+        "scope_question": {
+          "$ref": "#/$defs/longText"
+        },
+        "status": {
+          "enum": [
+            "draft",
+            "internal_review",
+            "unlisted_preview",
+            "public_alpha",
+            "contested",
+            "retired"
+          ]
+        },
+        "is_synthetic": {
+          "type": "boolean"
+        },
+        "subject_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^subject-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        },
+        "temporal_scope": {
+          "$ref": "#/$defs/timeScope"
+        },
+        "geographic_scope": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/shortText"
+          }
+        },
+        "limitations": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/longText"
+          }
+        },
+        "correction_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "release": {
+          "$ref": "#/$defs/release"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "unlisted_preview",
+                  "public_alpha",
+                  "contested"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "correction_path": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "release": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "release_id",
+        "created_at",
+        "created_by_ref",
+        "previous_release_id",
+        "public_release"
+      ],
+      "properties": {
+        "release_id": {
+          "type": "string",
+          "pattern": "^release-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "created_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "created_by_ref": {
+          "type": "string",
+          "pattern": "^reviewer-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "previous_release_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^release-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "public_release": {
+          "type": "boolean"
+        }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "subject_id",
+        "subject_type",
+        "display_name",
+        "public_role_context",
+        "jurisdiction",
+        "temporal_scope",
+        "notes"
+      ],
+      "properties": {
+        "subject_id": {
+          "type": "string",
+          "pattern": "^subject-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "subject_type": {
+          "enum": [
+            "project",
+            "institution",
+            "public_program",
+            "policy",
+            "contract",
+            "event"
+          ]
+        },
+        "display_name": {
+          "$ref": "#/$defs/shortText"
+        },
+        "public_role_context": {
+          "$ref": "#/$defs/longText"
+        },
+        "jurisdiction": {
+          "$ref": "#/$defs/shortText"
+        },
+        "temporal_scope": {
+          "$ref": "#/$defs/timeScope"
+        },
+        "notes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/longText"
+          }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "source_class",
+        "source_type",
+        "title",
+        "publisher",
+        "url",
+        "archive_url",
+        "published_at",
+        "accessed_at",
+        "jurisdiction",
+        "content_hash",
+        "license_notes",
+        "handling_notes"
+      ],
+      "properties": {
+        "source_id": {
+          "type": "string",
+          "pattern": "^source-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "source_class": {
+          "enum": [
+            "A",
+            "B",
+            "C",
+            "D"
+          ]
+        },
+        "source_type": {
+          "enum": [
+            "law",
+            "budget",
+            "procurement",
+            "filing",
+            "audit",
+            "court_record",
+            "official_dataset",
+            "research",
+            "journalism",
+            "ngo_report",
+            "local_reporting",
+            "lead"
+          ]
+        },
+        "title": {
+          "$ref": "#/$defs/shortText"
+        },
+        "publisher": {
+          "$ref": "#/$defs/shortText"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "archive_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "published_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "accessed_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "jurisdiction": {
+          "$ref": "#/$defs/shortText"
+        },
+        "content_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "license_notes": {
+          "$ref": "#/$defs/longText"
+        },
+        "handling_notes": {
+          "$ref": "#/$defs/longText"
+        }
+      }
+    },
+    "evidenceItem": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "evidence_id",
+        "source_id",
+        "locator",
+        "observation",
+        "excerpt",
+        "captured_at",
+        "public_safe",
+        "handling_notes"
+      ],
+      "properties": {
+        "evidence_id": {
+          "type": "string",
+          "pattern": "^evidence-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "source_id": {
+          "type": "string",
+          "pattern": "^source-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "locator": {
+          "$ref": "#/$defs/shortText"
+        },
+        "observation": {
+          "$ref": "#/$defs/longText"
+        },
+        "excerpt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 500
+        },
+        "captured_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "public_safe": {
+          "type": "boolean"
+        },
+        "handling_notes": {
+          "$ref": "#/$defs/longText"
+        }
+      }
+    },
+    "evidenceLink": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "evidence_id",
+        "relationship"
+      ],
+      "properties": {
+        "evidence_id": {
+          "type": "string",
+          "pattern": "^evidence-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "relationship": {
+          "enum": [
+            "supports",
+            "contradicts",
+            "contextualizes"
+          ]
+        }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "claim_id",
+        "statement",
+        "claim_kind",
+        "state",
+        "subject_ids",
+        "evidence_links",
+        "temporal_scope",
+        "place",
+        "reviewer_refs",
+        "review_due",
+        "supersedes_claim_id"
+      ],
+      "properties": {
+        "claim_id": {
+          "type": "string",
+          "pattern": "^claim-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "statement": {
+          "$ref": "#/$defs/longText"
+        },
+        "claim_kind": {
+          "enum": [
+            "fact",
+            "attributed_allegation",
+            "inference"
+          ]
+        },
+        "state": {
+          "enum": [
+            "draft",
+            "sourced",
+            "reviewed",
+            "publishable",
+            "contested",
+            "corrected",
+            "retired"
+          ]
+        },
+        "subject_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^subject-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        },
+        "evidence_links": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/evidenceLink"
+          }
+        },
+        "temporal_scope": {
+          "$ref": "#/$defs/timeScope"
+        },
+        "place": {
+          "$ref": "#/$defs/shortText"
+        },
+        "reviewer_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^reviewer-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        },
+        "review_due": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "supersedes_claim_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^claim-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "enum": [
+                  "sourced",
+                  "reviewed",
+                  "publishable",
+                  "contested",
+                  "corrected",
+                  "retired"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence_links": {
+                "type": "array",
+                "minItems": 1,
+                "contains": {
+                  "type": "object",
+                  "properties": {
+                    "relationship": {
+                      "enum": [
+                        "supports",
+                        "contradicts"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "relationship"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "enum": [
+                  "reviewed",
+                  "publishable",
+                  "contested",
+                  "corrected",
+                  "retired"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "properties": {
+              "reviewer_refs": {
+                "type": "array",
+                "minItems": 1
+              },
+              "review_due": {
+                "type": "string",
+                "format": "date"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "assessment": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "assessment_id",
+        "lens",
+        "direction",
+        "confidence",
+        "rationale",
+        "supporting_claim_ids",
+        "counter_claim_ids",
+        "assessor_refs",
+        "assessed_at",
+        "review_due"
+      ],
+      "properties": {
+        "assessment_id": {
+          "type": "string",
+          "pattern": "^assessment-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "lens": {
+          "enum": [
+            "consent_and_agency",
+            "distribution_of_benefits_and_burdens",
+            "transparency_and_answerability",
+            "resource_stewardship",
+            "reciprocity_and_cooperation",
+            "concentration_and_capture_risk"
+          ]
+        },
+        "direction": {
+          "enum": [
+            "cooperation_supporting",
+            "extraction_risk",
+            "mixed",
+            "unclear"
+          ]
+        },
+        "confidence": {
+          "enum": [
+            "insufficient",
+            "emerging",
+            "substantiated",
+            "contested"
+          ]
+        },
+        "rationale": {
+          "$ref": "#/$defs/longText"
+        },
+        "supporting_claim_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^claim-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        },
+        "counter_claim_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^claim-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        },
+        "assessor_refs": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^reviewer-[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        },
+        "assessed_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "review_due": {
+          "$ref": "#/$defs/date"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "confidence": {
+                "const": "substantiated"
+              }
+            },
+            "required": [
+              "confidence"
+            ]
+          },
+          "then": {
+            "properties": {
+              "supporting_claim_ids": {
+                "type": "array",
+                "minItems": 2
+              }
+            }
+          }
+        }
+      ]
+    },
+    "reviewEvent": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "review_event_id",
+        "target_type",
+        "target_id",
+        "action",
+        "actor_role",
+        "actor_ref",
+        "timestamp",
+        "reason",
+        "changed_fields",
+        "supersedes_record_id"
+      ],
+      "properties": {
+        "review_event_id": {
+          "type": "string",
+          "pattern": "^review-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "target_type": {
+          "enum": [
+            "case",
+            "subject",
+            "source",
+            "evidence_item",
+            "claim",
+            "assessment",
+            "correction_request"
+          ]
+        },
+        "target_id": {
+          "$ref": "#/$defs/shortText"
+        },
+        "action": {
+          "enum": [
+            "created",
+            "sourced",
+            "reviewed",
+            "approved_for_publication",
+            "contested",
+            "corrected",
+            "retired",
+            "superseded",
+            "correction_received"
+          ]
+        },
+        "actor_role": {
+          "enum": [
+            "steward",
+            "reviewer",
+            "researcher",
+            "correction_handler"
+          ]
+        },
+        "actor_ref": {
+          "type": "string",
+          "pattern": "^reviewer-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "timestamp": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "reason": {
+          "$ref": "#/$defs/longText"
+        },
+        "changed_fields": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/shortText"
+          }
+        },
+        "supersedes_record_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 240
+        }
+      }
+    },
+    "correctionRequest": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/safePropertyName"
+      },
+      "additionalProperties": false,
+      "required": [
+        "correction_id",
+        "request_reference",
+        "target_type",
+        "target_id",
+        "summary",
+        "status",
+        "received_at",
+        "resolved_at",
+        "resolution_note"
+      ],
+      "properties": {
+        "correction_id": {
+          "type": "string",
+          "pattern": "^correction-[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "request_reference": {
+          "$ref": "#/$defs/shortText"
+        },
+        "target_type": {
+          "enum": [
+            "case",
+            "subject",
+            "source",
+            "evidence_item",
+            "claim",
+            "assessment"
+          ]
+        },
+        "target_id": {
+          "$ref": "#/$defs/shortText"
+        },
+        "summary": {
+          "$ref": "#/$defs/longText"
+        },
+        "status": {
+          "enum": [
+            "received",
+            "under_review",
+            "accepted",
+            "partially_accepted",
+            "rejected"
+          ]
+        },
+        "received_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "resolved_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "resolution_note": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4000
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "accepted",
+                  "partially_accepted",
+                  "rejected"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "resolved_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "resolution_note": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 4000
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/behavior-atlas-validate.ps1
+++ b/scripts/behavior-atlas-validate.ps1
@@ -1,0 +1,352 @@
+param(
+  [string]$SchemaPath = "docs/behavior-atlas/schema/v0.1.schema.json",
+  [string]$DataPath = "docs/behavior-atlas/examples/synthetic-case.json",
+  [switch]$RequireSynthetic
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+
+function Resolve-RepoPath {
+  param([string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
+  return Join-Path $RepoRoot $Path
+}
+
+$script:ValidationErrors = @()
+
+function Add-ValidationError {
+  param([string]$Message)
+  $script:ValidationErrors += $Message
+}
+
+function Get-PropertyValue {
+  param(
+    [object]$Object,
+    [string]$Name
+  )
+  if ($null -eq $Object) { return $null }
+  $property = $Object.PSObject.Properties[$Name]
+  if ($null -eq $property) { return $null }
+  return $property.Value
+}
+
+function Test-ForbiddenProperties {
+  param(
+    [object]$Node,
+    [string]$Path = '$'
+  )
+
+  if ($null -eq $Node -or $Node -is [string] -or $Node.GetType().IsValueType) { return }
+
+  if ($Node -is [System.Collections.IEnumerable] -and
+      $Node -isnot [System.Collections.IDictionary] -and
+      $Node -isnot [System.Management.Automation.PSCustomObject]) {
+    $index = 0
+    foreach ($item in $Node) {
+      Test-ForbiddenProperties -Node $item -Path ("{0}[{1}]" -f $Path, $index)
+      $index++
+    }
+    return
+  }
+
+  $forbidden = @(
+    'score',
+    'rank',
+    'ranking',
+    'person_score',
+    'reputation_score',
+    'moral_label',
+    'guilt_finding',
+    'inferred_motive',
+    'composite_score',
+    'automatic_publication'
+  )
+
+  foreach ($property in $Node.PSObject.Properties) {
+    $name = $property.Name.ToLowerInvariant()
+    if ($forbidden -contains $name) {
+      Add-ValidationError ("Forbidden public field at {0}.{1}" -f $Path, $property.Name)
+    }
+    Test-ForbiddenProperties -Node $property.Value -Path ("{0}.{1}" -f $Path, $property.Name)
+  }
+}
+
+function New-IdIndex {
+  param(
+    [object[]]$Items,
+    [string]$IdProperty,
+    [string]$CollectionName
+  )
+
+  $index = @{}
+  foreach ($item in @($Items)) {
+    $id = Get-PropertyValue -Object $item -Name $IdProperty
+    if ([string]::IsNullOrWhiteSpace([string]$id)) {
+      Add-ValidationError ("{0} contains a record without {1}." -f $CollectionName, $IdProperty)
+      continue
+    }
+    if ($index.ContainsKey([string]$id)) {
+      Add-ValidationError ("Duplicate {0} '{1}' in {2}." -f $IdProperty, $id, $CollectionName)
+      continue
+    }
+    $index[[string]$id] = $item
+  }
+  return $index
+}
+
+function Test-Reference {
+  param(
+    [hashtable]$Index,
+    [string]$Id,
+    [string]$Context
+  )
+  if ([string]::IsNullOrWhiteSpace($Id) -or -not $Index.ContainsKey($Id)) {
+    Add-ValidationError ("Broken reference '{0}' at {1}." -f $Id, $Context)
+  }
+}
+
+function Test-DateValue {
+  param(
+    [object]$Value,
+    [string]$Context,
+    [switch]$AllowNull
+  )
+  if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) {
+    if (-not $AllowNull) { Add-ValidationError ("Missing date value at {0}." -f $Context) }
+    return
+  }
+  $parsed = [DateTimeOffset]::MinValue
+  if (-not [DateTimeOffset]::TryParse([string]$Value, [ref]$parsed)) {
+    Add-ValidationError ("Invalid date or date-time '{0}' at {1}." -f $Value, $Context)
+  }
+}
+
+$schemaAbs = Resolve-RepoPath -Path $SchemaPath
+$dataAbs = Resolve-RepoPath -Path $DataPath
+
+if (-not (Test-Path $schemaAbs)) { throw "Schema not found: $schemaAbs" }
+if (-not (Test-Path $dataAbs)) { throw "Data file not found: $dataAbs" }
+
+try {
+  $schema = Get-Content $schemaAbs -Raw | ConvertFrom-Json
+} catch {
+  throw "Schema JSON is invalid: $($_.Exception.Message)"
+}
+
+try {
+  $data = Get-Content $dataAbs -Raw | ConvertFrom-Json
+} catch {
+  throw "Data JSON is invalid: $($_.Exception.Message)"
+}
+
+$schemaDraft = Get-PropertyValue -Object $schema -Name '$schema'
+if ($schemaDraft -ne 'https://json-schema.org/draft/2020-12/schema') {
+  Add-ValidationError "Schema must declare JSON Schema Draft 2020-12."
+}
+
+if ((Get-PropertyValue -Object $data -Name 'schema_version') -ne '0.1') {
+  Add-ValidationError "Data schema_version must be '0.1'."
+}
+
+$requiredCollections = @(
+  'subjects',
+  'sources',
+  'evidence_items',
+  'claims',
+  'assessments',
+  'review_events',
+  'correction_requests'
+)
+foreach ($name in $requiredCollections) {
+  if ($null -eq $data.PSObject.Properties[$name]) {
+    Add-ValidationError ("Missing root collection '{0}'." -f $name)
+  }
+}
+
+Test-ForbiddenProperties -Node $data
+
+$subjects = @((Get-PropertyValue -Object $data -Name 'subjects'))
+$sources = @((Get-PropertyValue -Object $data -Name 'sources'))
+$evidenceItems = @((Get-PropertyValue -Object $data -Name 'evidence_items'))
+$claims = @((Get-PropertyValue -Object $data -Name 'claims'))
+$assessments = @((Get-PropertyValue -Object $data -Name 'assessments'))
+$reviewEvents = @((Get-PropertyValue -Object $data -Name 'review_events'))
+$corrections = @((Get-PropertyValue -Object $data -Name 'correction_requests'))
+
+$subjectIndex = New-IdIndex -Items $subjects -IdProperty 'subject_id' -CollectionName 'subjects'
+$sourceIndex = New-IdIndex -Items $sources -IdProperty 'source_id' -CollectionName 'sources'
+$evidenceIndex = New-IdIndex -Items $evidenceItems -IdProperty 'evidence_id' -CollectionName 'evidence_items'
+$claimIndex = New-IdIndex -Items $claims -IdProperty 'claim_id' -CollectionName 'claims'
+$assessmentIndex = New-IdIndex -Items $assessments -IdProperty 'assessment_id' -CollectionName 'assessments'
+$reviewIndex = New-IdIndex -Items $reviewEvents -IdProperty 'review_event_id' -CollectionName 'review_events'
+$correctionIndex = New-IdIndex -Items $corrections -IdProperty 'correction_id' -CollectionName 'correction_requests'
+
+$allRecords = @{}
+$caseId = [string](Get-PropertyValue -Object $data.case -Name 'case_id')
+if ([string]::IsNullOrWhiteSpace($caseId)) {
+  Add-ValidationError "case.case_id is required."
+} else {
+  $allRecords[$caseId] = $data.case
+}
+
+foreach ($index in @($subjectIndex, $sourceIndex, $evidenceIndex, $claimIndex, $assessmentIndex, $reviewIndex, $correctionIndex)) {
+  foreach ($id in $index.Keys) {
+    if ($allRecords.ContainsKey($id)) {
+      Add-ValidationError ("Record id '{0}' is duplicated across collections." -f $id)
+    } else {
+      $allRecords[$id] = $index[$id]
+    }
+  }
+}
+
+$allowedSubjectTypes = @('project', 'institution', 'public_program', 'policy', 'contract', 'event')
+foreach ($subject in $subjects) {
+  $subjectType = [string](Get-PropertyValue -Object $subject -Name 'subject_type')
+  if ($allowedSubjectTypes -notcontains $subjectType) {
+    Add-ValidationError ("Subject '{0}' has forbidden or unknown type '{1}'." -f $subject.subject_id, $subjectType)
+  }
+}
+
+foreach ($subjectId in @($data.case.subject_ids)) {
+  Test-Reference -Index $subjectIndex -Id ([string]$subjectId) -Context 'case.subject_ids'
+}
+
+if ($RequireSynthetic) {
+  if (-not [bool](Get-PropertyValue -Object $data.case -Name 'is_synthetic')) {
+    Add-ValidationError "-RequireSynthetic requires case.is_synthetic = true."
+  }
+  if (@('draft', 'internal_review') -notcontains [string]$data.case.status) {
+    Add-ValidationError "Synthetic M1 fixtures must stay in draft or internal_review status."
+  }
+  if ([bool]$data.case.release.public_release) {
+    Add-ValidationError "Synthetic M1 fixtures must set release.public_release = false."
+  }
+}
+
+if (@('unlisted_preview', 'public_alpha', 'contested') -contains [string]$data.case.status) {
+  if ([string]::IsNullOrWhiteSpace([string]$data.case.correction_path)) {
+    Add-ValidationError "Preview, public, or contested cases require case.correction_path."
+  }
+}
+
+Test-DateValue -Value $data.case.release.created_at -Context 'case.release.created_at'
+
+foreach ($source in $sources) {
+  if (@('A', 'B', 'C', 'D') -notcontains [string]$source.source_class) {
+    Add-ValidationError ("Source '{0}' has unknown class '{1}'." -f $source.source_id, $source.source_class)
+  }
+  if ([string]$source.content_hash -notmatch '^sha256:[a-f0-9]{64}$') {
+    Add-ValidationError ("Source '{0}' has an invalid content_hash." -f $source.source_id)
+  }
+  Test-DateValue -Value $source.accessed_at -Context ("sources[{0}].accessed_at" -f $source.source_id)
+}
+
+foreach ($evidence in $evidenceItems) {
+  Test-Reference -Index $sourceIndex -Id ([string]$evidence.source_id) -Context ("evidence_items[{0}].source_id" -f $evidence.evidence_id)
+  Test-DateValue -Value $evidence.captured_at -Context ("evidence_items[{0}].captured_at" -f $evidence.evidence_id)
+}
+
+$reviewedStates = @('reviewed', 'publishable', 'contested', 'corrected', 'retired')
+$sourcedStates = @('sourced', 'reviewed', 'publishable', 'contested', 'corrected', 'retired')
+
+foreach ($claim in $claims) {
+  foreach ($subjectId in @($claim.subject_ids)) {
+    Test-Reference -Index $subjectIndex -Id ([string]$subjectId) -Context ("claims[{0}].subject_ids" -f $claim.claim_id)
+  }
+
+  $hasEvidence = $false
+  foreach ($link in @($claim.evidence_links)) {
+    $evidenceId = [string]$link.evidence_id
+    Test-Reference -Index $evidenceIndex -Id $evidenceId -Context ("claims[{0}].evidence_links" -f $claim.claim_id)
+    if (@('supports', 'contradicts') -contains [string]$link.relationship) { $hasEvidence = $true }
+
+    if ([string]$claim.state -eq 'publishable' -and $evidenceIndex.ContainsKey($evidenceId)) {
+      $evidence = $evidenceIndex[$evidenceId]
+      if (-not [bool]$evidence.public_safe) {
+        Add-ValidationError ("Publishable claim '{0}' references evidence not marked public_safe." -f $claim.claim_id)
+      }
+      $sourceId = [string]$evidence.source_id
+      if ($sourceIndex.ContainsKey($sourceId) -and [string]$sourceIndex[$sourceId].source_class -eq 'D') {
+        Add-ValidationError ("Publishable claim '{0}' relies on class D lead material." -f $claim.claim_id)
+      }
+    }
+  }
+
+  if ($sourcedStates -contains [string]$claim.state -and -not $hasEvidence) {
+    Add-ValidationError ("Claim '{0}' is {1} but has no supporting or contradicting evidence link." -f $claim.claim_id, $claim.state)
+  }
+  if ($reviewedStates -contains [string]$claim.state) {
+    if (@($claim.reviewer_refs).Count -lt 1) {
+      Add-ValidationError ("Reviewed claim '{0}' has no reviewer_refs." -f $claim.claim_id)
+    }
+    Test-DateValue -Value $claim.review_due -Context ("claims[{0}].review_due" -f $claim.claim_id)
+  }
+  if ($null -ne $claim.supersedes_claim_id) {
+    Test-Reference -Index $claimIndex -Id ([string]$claim.supersedes_claim_id) -Context ("claims[{0}].supersedes_claim_id" -f $claim.claim_id)
+  }
+}
+
+foreach ($assessment in $assessments) {
+  $supporting = @($assessment.supporting_claim_ids)
+  $counter = @($assessment.counter_claim_ids)
+  foreach ($claimId in $supporting) {
+    Test-Reference -Index $claimIndex -Id ([string]$claimId) -Context ("assessments[{0}].supporting_claim_ids" -f $assessment.assessment_id)
+    if ($counter -contains $claimId) {
+      Add-ValidationError ("Assessment '{0}' uses claim '{1}' as both support and counterevidence." -f $assessment.assessment_id, $claimId)
+    }
+  }
+  foreach ($claimId in $counter) {
+    Test-Reference -Index $claimIndex -Id ([string]$claimId) -Context ("assessments[{0}].counter_claim_ids" -f $assessment.assessment_id)
+  }
+  if ([string]$assessment.confidence -eq 'substantiated' -and $supporting.Count -lt 2) {
+    Add-ValidationError ("Substantiated assessment '{0}' requires at least two supporting claims." -f $assessment.assessment_id)
+  }
+  if ([string]$assessment.direction -eq 'mixed' -and $counter.Count -lt 1) {
+    Add-ValidationError ("Mixed assessment '{0}' requires at least one counter claim." -f $assessment.assessment_id)
+  }
+  Test-DateValue -Value $assessment.assessed_at -Context ("assessments[{0}].assessed_at" -f $assessment.assessment_id)
+  Test-DateValue -Value $assessment.review_due -Context ("assessments[{0}].review_due" -f $assessment.assessment_id)
+}
+
+foreach ($event in $reviewEvents) {
+  Test-Reference -Index $allRecords -Id ([string]$event.target_id) -Context ("review_events[{0}].target_id" -f $event.review_event_id)
+  Test-DateValue -Value $event.timestamp -Context ("review_events[{0}].timestamp" -f $event.review_event_id)
+  if ($null -ne $event.supersedes_record_id) {
+    Test-Reference -Index $allRecords -Id ([string]$event.supersedes_record_id) -Context ("review_events[{0}].supersedes_record_id" -f $event.review_event_id)
+  }
+}
+
+foreach ($correction in $corrections) {
+  Test-Reference -Index $allRecords -Id ([string]$correction.target_id) -Context ("correction_requests[{0}].target_id" -f $correction.correction_id)
+  Test-DateValue -Value $correction.received_at -Context ("correction_requests[{0}].received_at" -f $correction.correction_id)
+  if (@('accepted', 'partially_accepted', 'rejected') -contains [string]$correction.status) {
+    Test-DateValue -Value $correction.resolved_at -Context ("correction_requests[{0}].resolved_at" -f $correction.correction_id)
+    if ([string]::IsNullOrWhiteSpace([string]$correction.resolution_note)) {
+      Add-ValidationError ("Resolved correction '{0}' requires resolution_note." -f $correction.correction_id)
+    }
+  }
+}
+
+if ($script:ValidationErrors.Count -gt 0) {
+  Write-Host "Behavior Atlas validation FAILED" -ForegroundColor Red
+  foreach ($message in $script:ValidationErrors) {
+    Write-Host (" - {0}" -f $message) -ForegroundColor Red
+  }
+  exit 1
+}
+
+Write-Host "Behavior Atlas validation OK" -ForegroundColor Green
+Write-Host ("Schema: {0}" -f $SchemaPath)
+Write-Host ("Data:   {0}" -f $DataPath)
+Write-Host ("Counts: {0} subject(s), {1} source(s), {2} evidence item(s), {3} claim(s), {4} assessment(s), {5} review event(s), {6} correction request(s)" -f `
+  $subjects.Count,
+  $sources.Count,
+  $evidenceItems.Count,
+  $claims.Count,
+  $assessments.Count,
+  $reviewEvents.Count,
+  $corrections.Count)
+exit 0


### PR DESCRIPTION
## What changed

- add the experimental Behavior Atlas case-bundle schema at `docs/behavior-atlas/schema/v0.1.schema.json`
- add one explicitly fictional, non-personal fixture at `docs/behavior-atlas/examples/synthetic-case.json`
- add a PowerShell semantic validator for reference closure, public-safety rules, review requirements, counterevidence, and forbidden fields
- run that validator from the existing `repo-health` workflow
- register the schema sandbox in Project Atlas and regenerate Atlas to 31 entries

## Why

ADR-0006 defines M1 as a schema sandbox before real cases or public interfaces. This batch turns the evidence chain—subject, source, evidence item, atomic claim, assessment, review event, and correction request—into a testable contract without introducing real subject data.

## Guardrails preserved

- no person subject type
- no score, rank, moral label, guilt finding, inferred motive, composite score, or automatic-publication field
- no real organization, person, place, contract, allegation, or source
- no public Behavior Atlas route, database, API, scraper, watcher, or publisher
- the synthetic release is marked non-public and remains in `internal_review`

## Validation

- strict JSON Schema Draft 2020-12 validation passed with URI/date formats enabled
- negative schema checks rejected a forbidden `score` field and a `person` subject
- semantic preflight closed every fixture reference from assessment to claim, evidence item, source, and subject
- branch readback matched all six intended files exactly
- registry and generated Atlas agree at 31 unique active entries
- all 31 registered paths resolve on the branch
- final diff is limited to the intended six files

Repository validation is complete: all four workflows passed, including the new PowerShell semantic-validator step in `repo-health`.
