### PR TITLE
docs: add GroundMesh coordination field v0.1

### DIFF
--- a/docs/assistant-brief.md
+++ b/docs/assistant-brief.md
@@ -2,6 +2,7 @@
 
 ## How we work (directives)
 - Atlas-first: Consult docs/atlas/registry.json + Atlas page before adding or changing anything.
+- Coordination-field first: Before adding need/capacity matching, allocation, metric, or scoring logic, read `docs/coordination/coordination-field.md` and `docs/coordination/coordination-field.v0.1.json`; preserve consent, context, evidence provenance, non-capture, no person-worth scoring, and no autonomous allocation.
 - Smallest safe change: Prefer incremental, reversible edits.
 - Small batches: Prefer one meaningful chunk at a time, then summarize what changed and what remains next.
 - Recovery before rush: If a session or approval flow freezes, inspect current state first and resume from the last stable point.

--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -49,7 +49,12 @@
     h1 { margin: 14px 0 10px; font-size: clamp(2rem, 4.5vw, 3.4rem); line-height: 1.04; }
     p { margin: 0; color: var(--muted); }
     .lede { max-width: 68ch; font-size: 1.05rem; }
-    .quicklinks, .stats { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 18px; }
+    .quicklinks, .stats {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 18px;
+    }
     .quicklinks a {
       display: inline-block;
       padding: 10px 14px;
@@ -60,7 +65,10 @@
       text-decoration: none;
       font: 600 .95rem/1.2 "Segoe UI", Arial, sans-serif;
     }
-    .quicklinks a.secondary { background: transparent; color: var(--accent); }
+    .quicklinks a.secondary {
+      background: transparent;
+      color: var(--accent);
+    }
     .stat {
       min-width: 150px;
       padding: 14px 16px;
@@ -77,13 +85,30 @@
       letter-spacing: .04em;
     }
     .stat strong { font-size: 1.55rem; }
-    .guide { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin-top: 20px; }
+    .guide {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+      margin-top: 20px;
+    }
     .card { padding: 18px; }
-    .card h2 { margin: 0 0 8px; font-size: 1.08rem; font-family: "Segoe UI", Arial, sans-serif; }
-    .table-card { margin-top: 20px; overflow: hidden; }
+    .card h2 {
+      margin: 0 0 8px;
+      font-size: 1.08rem;
+      font-family: "Segoe UI", Arial, sans-serif;
+    }
+    .table-card {
+      margin-top: 20px;
+      overflow: hidden;
+    }
     .table-wrap { overflow-x: auto; }
     table { width: 100%; border-collapse: collapse; }
-    th, td { padding: 0.85rem 0.8rem; border-top: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th, td {
+      padding: 0.85rem 0.8rem;
+      border-top: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }
     th {
       color: var(--muted);
       font: 600 .82rem/1.2 "Segoe UI", Arial, sans-serif;
@@ -92,7 +117,11 @@
       background: rgba(219,236,227,.45);
     }
     tr:first-child td { border-top: 0; }
-    .id-link { color: var(--accent); text-decoration: none; font: 700 .95rem/1.2 "Segoe UI", Arial, sans-serif; }
+    .id-link {
+      color: var(--accent);
+      text-decoration: none;
+      font: 700 .95rem/1.2 "Segoe UI", Arial, sans-serif;
+    }
     .id-link:hover { text-decoration: underline; }
     .id-link.missing { color: #915d21; }
     .chip, .status {
@@ -102,9 +131,21 @@
       font: 600 .8rem/1.2 "Segoe UI", Arial, sans-serif;
       white-space: nowrap;
     }
-    .chip { background: #efe8dc; border: 1px solid #ddd1bd; color: #5f5646; }
-    .status { border: 1px solid #cfe0d7; background: #eff7f2; color: #20563f; }
-    .status-active { border-color: #cfe0d7; background: #eff7f2; color: #20563f; }
+    .chip {
+      background: #efe8dc;
+      border: 1px solid #ddd1bd;
+      color: #5f5646;
+    }
+    .status {
+      border: 1px solid #cfe0d7;
+      background: #eff7f2;
+      color: #20563f;
+    }
+    .status-active {
+      border-color: #cfe0d7;
+      background: #eff7f2;
+      color: #20563f;
+    }
     code {
       display: inline-block;
       padding: 0.15rem 0.4rem;
@@ -114,7 +155,11 @@
       font-family: Consolas, "Courier New", monospace;
       word-break: break-word;
     }
-    .meta { margin-top: 14px; color: var(--muted); font-size: 0.92rem; }
+    .meta {
+      margin-top: 14px;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
   </style>
 </head>
 <body>
@@ -131,56 +176,318 @@
         <a class="secondary" href="../landscape.html">Landscape</a>
       </div>
       <div class="stats">
-        <div class="stat"><span class="label">Entries</span><strong>34</strong></div>
-        <div class="stat"><span class="label">Active</span><strong>34</strong></div>
+        <div class="stat">
+          <span class="label">Entries</span>
+          <strong>34</strong>
+        </div>
+        <div class="stat">
+          <span class="label">Active</span>
+          <strong>34</strong>
+        </div>
       </div>
     </section>
 
     <section class="guide">
-      <article class="card"><h2>1. Orient first</h2><p>Scan the registry before creating new files, pages, or concepts.</p></article>
-      <article class="card"><h2>2. Reuse what exists</h2><p>Follow linked artifacts outward and prefer extension over duplication.</p></article>
-      <article class="card"><h2>3. Grow carefully</h2><p>When new artifacts are added, update the registry so humans and systems stay aligned.</p></article>
+      <article class="card">
+        <h2>1. Orient first</h2>
+        <p>Scan the registry before creating new files, pages, or concepts.</p>
+      </article>
+      <article class="card">
+        <h2>2. Reuse what exists</h2>
+        <p>Follow linked artifacts outward and prefer extension over duplication.</p>
+      </article>
+      <article class="card">
+        <h2>3. Grow carefully</h2>
+        <p>When new artifacts are added, update the registry so humans and systems stay aligned.</p>
+      </article>
     </section>
 
     <section class="card table-card">
       <div class="table-wrap">
         <table>
-          <thead><tr><th>ID</th><th>Name</th><th>Type</th><th>Status</th><th>Path</th><th>Summary</th></tr></thead>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Path</th>
+              <th>Summary</th>
+            </tr>
+          </thead>
           <tbody>
-            <tr><td><a class="id-link" href="../decisions/0001-why-atlas.md">ADR-0001</a></td><td><strong>Why Project Atlas</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0001-why-atlas.md</code></td><td>Establishes Atlas as the shared registry for repo orientation, safer changes, and lower duplication risk.</td></tr>
-            <tr><td><a class="id-link" href="../decisions/0002-groundmesh-world-relationship.md">ADR-0002</a></td><td><strong>Relationship Between GroundMesh World and GroundMesh</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0002-groundmesh-world-relationship.md</code></td><td>Keeps GroundMesh as the canonical core repo, keeps groundmesh-world as the narrative public seed, and merges by small translation steps rather than repo collapse.</td></tr>
-            <tr><td><a class="id-link" href="../decisions/0003-chatgpt-codex-github-operating-pattern.md">ADR-0003</a></td><td><strong>ChatGPT, Codex, and GitHub Operating Pattern</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0003-chatgpt-codex-github-operating-pattern.md</code></td><td>Establishes GitHub as the shared external spine between ChatGPT, Codex, and GroundMesh work so important state is anchored in visible project memory.</td></tr>
-            <tr><td><a class="id-link" href="../decisions/0004-active-dev-promotion-model.md">ADR-0004</a></td><td><strong>Active / Dev Promotion Model</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0004-active-dev-promotion-model.md</code></td><td>Keeps the ACTIVE / DEV instinct, but translates it into one canonical repo with main as the public lane, dev as staging when needed, and separate sensitive services only where risk truly differs.</td></tr>
-            <tr><td><a class="id-link" href="../decisions/0005-public-registration-pilot.md">ADR-0005</a></td><td><strong>Public Registration Begins as a Pilot</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0005-public-registration-pilot.md</code></td><td>Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates.</td></tr>
-            <tr><td><a class="id-link" href="../decisions/0006-behavior-atlas-evidence-pilot.md">ADR-0006</a></td><td><strong>Behavior Atlas Begins as an Evidence-First Pilot</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0006-behavior-atlas-evidence-pilot.md</code></td><td>Establishes the Behavior Atlas as an evidence-first, human-reviewed pilot that maps claims and patterns without person scoring or autonomous publication.</td></tr>
-            <tr><td><a class="id-link" href="../checklists/Registration_Interest_Triage_Checklist.md">CHECKLIST-REGISTRATION-INTEREST-TRIAGE</a></td><td><strong>Registration Interest Triage Checklist</strong></td><td><span class="chip">checklist</span></td><td><span class="status status-active">active</span></td><td><code>docs/checklists/Registration_Interest_Triage_Checklist.md</code></td><td>Smallest honest handling checklist for public registration-interest emails before any real pilot intake is open.</td></tr>
-            <tr><td><a class="id-link" href="../checklists/Registration_Pilot_Readiness_Checklist.md">CHECKLIST-REGISTRATION-PILOT</a></td><td><strong>Registration Pilot Readiness Checklist</strong></td><td><span class="chip">checklist</span></td><td><span class="status status-active">active</span></td><td><code>docs/checklists/Registration_Pilot_Readiness_Checklist.md</code></td><td>Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact.</td></tr>
-            <tr><td><a class="id-link" href="../coordination/coordination-field.v0.1.json">DATA-COORDINATION-FIELD-V0-1</a></td><td><strong>GroundMesh Coordination Field Machine Model v0.1</strong></td><td><span class="chip">data</span></td><td><span class="status status-active">active</span></td><td><code>docs/coordination/coordination-field.v0.1.json</code></td><td>Machine-readable companion defining coordination quantities, measurement rules, cooperation loops, non-capture constraints, Behavior Atlas questions, and guarded implementation stages.</td></tr>
-            <tr><td><a class="id-link" href="../assistant-brief.md">DOC-ASSISTANT-BRIEF</a></td><td><strong>Assistant Brief</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/assistant-brief.md</code></td><td>Defines Atlas-first workflow, smallest-safe-change practice, and the current stabilization focus.</td></tr>
-            <tr><td><a class="id-link" href="../glossary.md">DOC-GLOSSARY</a></td><td><strong>GroundMesh Glossary</strong></td><td><span class="chip">reference</span></td><td><span class="status status-active">active</span></td><td><code>docs/glossary.md</code></td><td>Compact shared language for Atlas, compute transparency, and contributor on-ramps.</td></tr>
-            <tr><td><a class="id-link" href="../echo_archive/EA-0001_soul-and-system.md">EA-0001</a></td><td><strong>The Soul and the System</strong></td><td><span class="chip">echo</span></td><td><span class="status status-active">active</span></td><td><code>docs/echo_archive/EA-0001_soul-and-system.md</code></td><td>Foundational reflection linking soul to relational balance and emotions to consequence, then translating that pattern into harmony-seeking CI behavior.</td></tr>
-            <tr><td><a class="id-link" href="../echo_archive/EA-0002_numbers-neighbor-and-coordination.md">EA-0002</a></td><td><strong>Numbers, Neighbor, and the Coordination Field</strong></td><td><span class="chip">echo</span></td><td><span class="status status-active">active</span></td><td><code>docs/echo_archive/EA-0002_numbers-neighbor-and-coordination.md</code></td><td>Reflection connecting numbers, hidden accounting boundaries, Jesus' teachings on neighbor, service, mammon, and non-retaliation, and GroundMesh's voluntary coordination posture.</td></tr>
-            <tr><td><a class="id-link" href="../invariants/GM-INV-VIII.md">GM-INV-VIII</a></td><td><strong>Continuity With Consent</strong></td><td><span class="chip">invariant</span></td><td><span class="status status-active">active</span></td><td><code>docs/invariants/GM-INV-VIII.md</code></td><td>Sustained participation must arise from voluntary re-engagement, not compulsion. Systems must preserve agency, rhythm, and the right to pause without loss of dignity.</td></tr>
-            <tr><td><a class="id-link" href="seed-trust-mesh-edge.md">GUIDE-ARCH-SEED-TRUST-MESH-EDGE</a></td><td><strong>GroundMesh Architecture: Seed / Trust / Mesh / Edge</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/atlas/seed-trust-mesh-edge.md</code></td><td>Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization.</td></tr>
-            <tr><td><a class="id-link" href="../coordination/coordination-field.md">GUIDE-COORDINATION-FIELD-V0-1</a></td><td><strong>GroundMesh Coordination Field v0.1</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/coordination/coordination-field.md</code></td><td>Human-readable model for exposing needs, capacity, commitments, delivery, gaps, externalities, and coordination failures without central planning, person scoring, or loss of consent.</td></tr>
-            <tr><td><a class="id-link" href="light-node-agent-contract.md">GUIDE-LIGHT-NODE-CONTRACT</a></td><td><strong>GroundMesh Light Node Agent Contract v1</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/atlas/light-node-agent-contract.md</code></td><td>Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract.</td></tr>
-            <tr><td><a class="id-link" href="groundmesh-new-chat-handoff.md">GUIDE-NEW-CHAT-HANDOFF</a></td><td><strong>GroundMesh New Chat Handoff</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/atlas/groundmesh-new-chat-handoff.md</code></td><td>Compact reload note for starting a new chat without losing the current GroundMesh state or falling into long recap mode.</td></tr>
-            <tr><td><a class="id-link" href="session-0001-codex-first-contact.md">NOTE-SESSION-0001</a></td><td><strong>Codex Session 0001: First Contact and Working Basis</strong></td><td><span class="chip">note</span></td><td><span class="status status-active">active</span></td><td><code>docs/atlas/session-0001-codex-first-contact.md</code></td><td>Tracked memory of the first major Codex GroundMesh session, including workflow doctrine, public-surface stabilization, and the first real registration pilot outcomes.</td></tr>
-            <tr><td><a class="id-link" href="../compute.html">PAGE-COMPUTE</a></td><td><strong>Compute Transparency</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/compute.html</code></td><td>Public snapshot page for non-sensitive grid metrics sourced from metrics.json.</td></tr>
-            <tr><td><a class="id-link" href="../contact.html">PAGE-CONTACT</a></td><td><strong>GroundMesh Contact</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/contact.html</code></td><td>Simple public contact path for questions, corrections, first contact, and participation guidance.</td></tr>
-            <tr><td><a class="id-link" href="../contribute.html">PAGE-CONTRIBUTE</a></td><td><strong>Contributors Hub</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/contribute.html</code></td><td>Primary public on-ramp for volunteers, issue filing, and low-friction participation.</td></tr>
-            <tr><td><a class="id-link" href="../get-started/index.html">PAGE-GET-STARTED</a></td><td><strong>GroundMesh Get Started</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/get-started/index.html</code></td><td>Builder-facing start page for local setup, health checks, Atlas-first work, and small-batch contributions.</td></tr>
-            <tr><td><a class="id-link" href="../index.html">PAGE-HOME</a></td><td><strong>GroundMesh Start Here</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/index.html</code></td><td>Unified public front door that joins the stronger narrative seed with the Atlas-backed docs layer.</td></tr>
-            <tr><td><a class="id-link" href="../landscape.html">PAGE-LANDSCAPE</a></td><td><strong>GroundMesh Landscape</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/landscape.html</code></td><td>Broad scan of live pages, local repos, mirrors, and adjacent web surfaces around GroundMesh.</td></tr>
-            <tr><td><a class="id-link" href="../map.html">PAGE-MAP</a></td><td><strong>GroundMesh Map</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/map.html</code></td><td>Public-facing orientation page for the project landscape and navigation.</td></tr>
-            <tr><td><a class="id-link" href="../privacy.html">PAGE-PRIVACY</a></td><td><strong>GroundMesh Privacy</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/privacy.html</code></td><td>Plain-language statement of the current public privacy posture, limits, and data-minimization rule.</td></tr>
-            <tr><td><a class="id-link" href="../register.html">PAGE-REGISTER</a></td><td><strong>GroundMesh Registration Status</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/register.html</code></td><td>Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot.</td></tr>
-            <tr><td><a class="id-link" href="../register-pilot.html">PAGE-REGISTER-PILOT</a></td><td><strong>GroundMesh Invited-Circle Registration Pilot</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/register-pilot.html</code></td><td>Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active.</td></tr>
-            <tr><td><a class="id-link" href="../behavior-atlas/schema/v0.1.schema.json">SCHEMA-BEHAVIOR-ATLAS-V0-1</a></td><td><strong>Behavior Atlas Schema Sandbox v0.1</strong></td><td><span class="chip">schema</span></td><td><span class="status status-active">active</span></td><td><code>docs/behavior-atlas/schema/v0.1.schema.json</code></td><td>Experimental M1 contract for synthetic, public-source case bundles, paired with a fictional fixture and semantic validator; forbids person subjects, scores, rankings, inferred motives, and autonomous publication.</td></tr>
-            <tr><td><a class="id-link" href="../data/status.json">STATUS-PUBLIC</a></td><td><strong>Public Status Snapshot</strong></td><td><span class="chip">data</span></td><td><span class="status status-active">active</span></td><td><code>docs/data/status.json</code></td><td>Tracks public health notes for the current docs surface and Atlas-backed pages.</td></tr>
-            <tr><td><a class="id-link" href="../templates/Registration_Pilot_Record.md">TEMPLATE-REGISTRATION-PILOT-RECORD</a></td><td><strong>Registration Pilot Record Template</strong></td><td><span class="chip">template</span></td><td><span class="status status-active">active</span></td><td><code>docs/templates/Registration_Pilot_Record.md</code></td><td>Reusable minimal record for one actual participant during the invited-circle registration pilot.</td></tr>
-            <tr><td><a class="id-link" href="../templates/Registration_Pilot_Scope_Canvas.md">TEMPLATE-REGISTRATION-PILOT-SCOPE</a></td><td><strong>Registration Pilot Scope Canvas</strong></td><td><span class="chip">template</span></td><td><span class="status status-active">active</span></td><td><code>docs/templates/Registration_Pilot_Scope_Canvas.md</code></td><td>Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact.</td></tr>
-            <tr><td><a class="id-link" href="../protocols/TP-03.md">TP-03</a></td><td><strong>Sustaining Resolve Without Compulsion</strong></td><td><span class="chip">protocol</span></td><td><span class="status status-active">active</span></td><td><code>docs/protocols/TP-03.md</code></td><td>Guides humans through pressure and delay without collapse or loss of agency; restores resolve through meaning, rhythm, and consent.</td></tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0001-why-atlas.md">ADR-0001</a></td>
+  <td><strong>Why Project Atlas</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0001-why-atlas.md</code></td>
+  <td>Establishes Atlas as the shared registry for repo orientation, safer changes, and lower duplication risk.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0002-groundmesh-world-relationship.md">ADR-0002</a></td>
+  <td><strong>Relationship Between GroundMesh World and GroundMesh</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0002-groundmesh-world-relationship.md</code></td>
+  <td>Keeps GroundMesh as the canonical core repo, keeps groundmesh-world as the narrative public seed, and merges by small translation steps rather than repo collapse.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0003-chatgpt-codex-github-operating-pattern.md">ADR-0003</a></td>
+  <td><strong>ChatGPT, Codex, and GitHub Operating Pattern</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0003-chatgpt-codex-github-operating-pattern.md</code></td>
+  <td>Establishes GitHub as the shared external spine between ChatGPT, Codex, and GroundMesh work so important state is anchored in visible project memory.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0004-active-dev-promotion-model.md">ADR-0004</a></td>
+  <td><strong>Active / Dev Promotion Model</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0004-active-dev-promotion-model.md</code></td>
+  <td>Keeps the ACTIVE / DEV instinct, but translates it into one canonical repo with main as the public lane, dev as staging when needed, and separate sensitive services only where risk truly differs.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0005-public-registration-pilot.md">ADR-0005</a></td>
+  <td><strong>Public Registration Begins as a Pilot</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0005-public-registration-pilot.md</code></td>
+  <td>Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../decisions/0006-behavior-atlas-evidence-pilot.md">ADR-0006</a></td>
+  <td><strong>Behavior Atlas Begins as an Evidence-First Pilot</strong></td>
+  <td><span class="chip">decision</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/decisions/0006-behavior-atlas-evidence-pilot.md</code></td>
+  <td>Establishes the Behavior Atlas as an evidence-first, human-reviewed pilot that maps claims and patterns without person scoring or autonomous publication.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../checklists/Registration_Interest_Triage_Checklist.md">CHECKLIST-REGISTRATION-INTEREST-TRIAGE</a></td>
+  <td><strong>Registration Interest Triage Checklist</strong></td>
+  <td><span class="chip">checklist</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/checklists/Registration_Interest_Triage_Checklist.md</code></td>
+  <td>Smallest honest handling checklist for public registration-interest emails before any real pilot intake is open.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../checklists/Registration_Pilot_Readiness_Checklist.md">CHECKLIST-REGISTRATION-PILOT</a></td>
+  <td><strong>Registration Pilot Readiness Checklist</strong></td>
+  <td><span class="chip">checklist</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/checklists/Registration_Pilot_Readiness_Checklist.md</code></td>
+  <td>Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../coordination/coordination-field.v0.1.json">DATA-COORDINATION-FIELD-V0-1</a></td>
+  <td><strong>GroundMesh Coordination Field Machine Model v0.1</strong></td>
+  <td><span class="chip">data</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/coordination/coordination-field.v0.1.json</code></td>
+  <td>Machine-readable companion defining coordination quantities, measurement rules, cooperation loops, non-capture constraints, Behavior Atlas questions, and guarded implementation stages.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../assistant-brief.md">DOC-ASSISTANT-BRIEF</a></td>
+  <td><strong>Assistant Brief</strong></td>
+  <td><span class="chip">guide</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/assistant-brief.md</code></td>
+  <td>Defines Atlas-first workflow, smallest-safe-change practice, and the current stabilization focus.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../glossary.md">DOC-GLOSSARY</a></td>
+  <td><strong>GroundMesh Glossary</strong></td>
+  <td><span class="chip">reference</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/glossary.md</code></td>
+  <td>Compact shared language for Atlas, compute transparency, and contributor on-ramps.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../echo_archive/EA-0001_soul-and-system.md">EA-0001</a></td>
+  <td><strong>The Soul and the System</strong></td>
+  <td><span class="chip">echo</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/echo_archive/EA-0001_soul-and-system.md</code></td>
+  <td>Foundational reflection linking soul to relational balance and emotions to consequence, then translating that pattern into harmony-seeking CI behavior.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../echo_archive/EA-0002_numbers-neighbor-and-coordination.md">EA-0002</a></td>
+  <td><strong>Numbers, Neighbor, and the Coordination Field</strong></td>
+  <td><span class="chip">echo</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/echo_archive/EA-0002_numbers-neighbor-and-coordination.md</code></td>
+  <td>Reflection connecting numbers, hidden accounting boundaries, Jesus&#39; teachings on neighbor, service, mammon, and non-retaliation, and GroundMesh&#39;s voluntary coordination posture.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../invariants/GM-INV-VIII.md">GM-INV-VIII</a></td>
+  <td><strong>Continuity With Consent</strong></td>
+  <td><span class="chip">invariant</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/invariants/GM-INV-VIII.md</code></td>
+  <td>Sustained participation must arise from voluntary re-engagement, not compulsion. Systems must preserve agency, rhythm, and the right to pause without loss of dignity.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="seed-trust-mesh-edge.md">GUIDE-ARCH-SEED-TRUST-MESH-EDGE</a></td>
+  <td><strong>GroundMesh Architecture: Seed / Trust / Mesh / Edge</strong></td>
+  <td><span class="chip">guide</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/atlas/seed-trust-mesh-edge.md</code></td>
+  <td>Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../coordination/coordination-field.md">GUIDE-COORDINATION-FIELD-V0-1</a></td>
+  <td><strong>GroundMesh Coordination Field v0.1</strong></td>
+  <td><span class="chip">guide</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/coordination/coordination-field.md</code></td>
+  <td>Human-readable model for exposing needs, capacity, commitments, delivery, gaps, externalities, and coordination failures without central planning, person scoring, or loss of consent.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="light-node-agent-contract.md">GUIDE-LIGHT-NODE-CONTRACT</a></td>
+  <td><strong>GroundMesh Light Node Agent Contract v1</strong></td>
+  <td><span class="chip">guide</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/atlas/light-node-agent-contract.md</code></td>
+  <td>Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="groundmesh-new-chat-handoff.md">GUIDE-NEW-CHAT-HANDOFF</a></td>
+  <td><strong>GroundMesh New Chat Handoff</strong></td>
+  <td><span class="chip">guide</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/atlas/groundmesh-new-chat-handoff.md</code></td>
+  <td>Compact reload note for starting a new chat without losing the current GroundMesh state or falling into long recap mode.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="session-0001-codex-first-contact.md">NOTE-SESSION-0001</a></td>
+  <td><strong>Codex Session 0001: First Contact and Working Basis</strong></td>
+  <td><span class="chip">note</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/atlas/session-0001-codex-first-contact.md</code></td>
+  <td>Tracked memory of the first major Codex GroundMesh session, including workflow doctrine, public-surface stabilization, and the first real registration pilot outcomes.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../compute.html">PAGE-COMPUTE</a></td>
+  <td><strong>Compute Transparency</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/compute.html</code></td>
+  <td>Public snapshot page for non-sensitive grid metrics sourced from metrics.json.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../contact.html">PAGE-CONTACT</a></td>
+  <td><strong>GroundMesh Contact</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/contact.html</code></td>
+  <td>Simple public contact path for questions, corrections, first contact, and participation guidance.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../contribute.html">PAGE-CONTRIBUTE</a></td>
+  <td><strong>Contributors Hub</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/contribute.html</code></td>
+  <td>Primary public on-ramp for volunteers, issue filing, and low-friction participation.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../get-started/index.html">PAGE-GET-STARTED</a></td>
+  <td><strong>GroundMesh Get Started</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/get-started/index.html</code></td>
+  <td>Builder-facing start page for local setup, health checks, Atlas-first work, and small-batch contributions.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../index.html">PAGE-HOME</a></td>
+  <td><strong>GroundMesh Start Here</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/index.html</code></td>
+  <td>Unified public front door that joins the stronger narrative seed with the Atlas-backed docs layer.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../landscape.html">PAGE-LANDSCAPE</a></td>
+  <td><strong>GroundMesh Landscape</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/landscape.html</code></td>
+  <td>Broad scan of live pages, local repos, mirrors, and adjacent web surfaces around GroundMesh.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../map.html">PAGE-MAP</a></td>
+  <td><strong>GroundMesh Map</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/map.html</code></td>
+  <td>Public-facing orientation page for the project landscape and navigation.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../privacy.html">PAGE-PRIVACY</a></td>
+  <td><strong>GroundMesh Privacy</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/privacy.html</code></td>
+  <td>Plain-language statement of the current public privacy posture, limits, and data-minimization rule.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../register.html">PAGE-REGISTER</a></td>
+  <td><strong>GroundMesh Registration Status</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/register.html</code></td>
+  <td>Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../register-pilot.html">PAGE-REGISTER-PILOT</a></td>
+  <td><strong>GroundMesh Invited-Circle Registration Pilot</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/register-pilot.html</code></td>
+  <td>Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../behavior-atlas/schema/v0.1.schema.json">SCHEMA-BEHAVIOR-ATLAS-V0-1</a></td>
+  <td><strong>Behavior Atlas Schema Sandbox v0.1</strong></td>
+  <td><span class="chip">schema</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/behavior-atlas/schema/v0.1.schema.json</code></td>
+  <td>Experimental M1 contract for synthetic, public-source case bundles, paired with a fictional fixture and semantic validator; forbids person subjects, scores, rankings, inferred motives, and autonomous publication.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../data/status.json">STATUS-PUBLIC</a></td>
+  <td><strong>Public Status Snapshot</strong></td>
+  <td><span class="chip">data</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/data/status.json</code></td>
+  <td>Tracks public health notes for the current docs surface and Atlas-backed pages.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../templates/Registration_Pilot_Record.md">TEMPLATE-REGISTRATION-PILOT-RECORD</a></td>
+  <td><strong>Registration Pilot Record Template</strong></td>
+  <td><span class="chip">template</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/templates/Registration_Pilot_Record.md</code></td>
+  <td>Reusable minimal record for one actual participant during the invited-circle registration pilot.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../templates/Registration_Pilot_Scope_Canvas.md">TEMPLATE-REGISTRATION-PILOT-SCOPE</a></td>
+  <td><strong>Registration Pilot Scope Canvas</strong></td>
+  <td><span class="chip">template</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/templates/Registration_Pilot_Scope_Canvas.md</code></td>
+  <td>Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../protocols/TP-03.md">TP-03</a></td>
+  <td><strong>Sustaining Resolve Without Compulsion</strong></td>
+  <td><span class="chip">protocol</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/protocols/TP-03.md</code></td>
+  <td>Guides humans through pressure and delay without collapse or loss of agency; restores resolve through meaning, rhythm, and consent.</td>
+</tr>
           </tbody>
         </table>
       </div>

--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -49,12 +49,7 @@
     h1 { margin: 14px 0 10px; font-size: clamp(2rem, 4.5vw, 3.4rem); line-height: 1.04; }
     p { margin: 0; color: var(--muted); }
     .lede { max-width: 68ch; font-size: 1.05rem; }
-    .quicklinks, .stats {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-      margin-top: 18px;
-    }
+    .quicklinks, .stats { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 18px; }
     .quicklinks a {
       display: inline-block;
       padding: 10px 14px;
@@ -65,10 +60,7 @@
       text-decoration: none;
       font: 600 .95rem/1.2 "Segoe UI", Arial, sans-serif;
     }
-    .quicklinks a.secondary {
-      background: transparent;
-      color: var(--accent);
-    }
+    .quicklinks a.secondary { background: transparent; color: var(--accent); }
     .stat {
       min-width: 150px;
       padding: 14px 16px;
@@ -85,30 +77,13 @@
       letter-spacing: .04em;
     }
     .stat strong { font-size: 1.55rem; }
-    .guide {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 16px;
-      margin-top: 20px;
-    }
+    .guide { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin-top: 20px; }
     .card { padding: 18px; }
-    .card h2 {
-      margin: 0 0 8px;
-      font-size: 1.08rem;
-      font-family: "Segoe UI", Arial, sans-serif;
-    }
-    .table-card {
-      margin-top: 20px;
-      overflow: hidden;
-    }
+    .card h2 { margin: 0 0 8px; font-size: 1.08rem; font-family: "Segoe UI", Arial, sans-serif; }
+    .table-card { margin-top: 20px; overflow: hidden; }
     .table-wrap { overflow-x: auto; }
     table { width: 100%; border-collapse: collapse; }
-    th, td {
-      padding: 0.85rem 0.8rem;
-      border-top: 1px solid var(--line);
-      text-align: left;
-      vertical-align: top;
-    }
+    th, td { padding: 0.85rem 0.8rem; border-top: 1px solid var(--line); text-align: left; vertical-align: top; }
     th {
       color: var(--muted);
       font: 600 .82rem/1.2 "Segoe UI", Arial, sans-serif;
@@ -117,11 +92,7 @@
       background: rgba(219,236,227,.45);
     }
     tr:first-child td { border-top: 0; }
-    .id-link {
-      color: var(--accent);
-      text-decoration: none;
-      font: 700 .95rem/1.2 "Segoe UI", Arial, sans-serif;
-    }
+    .id-link { color: var(--accent); text-decoration: none; font: 700 .95rem/1.2 "Segoe UI", Arial, sans-serif; }
     .id-link:hover { text-decoration: underline; }
     .id-link.missing { color: #915d21; }
     .chip, .status {
@@ -131,21 +102,9 @@
       font: 600 .8rem/1.2 "Segoe UI", Arial, sans-serif;
       white-space: nowrap;
     }
-    .chip {
-      background: #efe8dc;
-      border: 1px solid #ddd1bd;
-      color: #5f5646;
-    }
-    .status {
-      border: 1px solid #cfe0d7;
-      background: #eff7f2;
-      color: #20563f;
-    }
-    .status-active {
-      border-color: #cfe0d7;
-      background: #eff7f2;
-      color: #20563f;
-    }
+    .chip { background: #efe8dc; border: 1px solid #ddd1bd; color: #5f5646; }
+    .status { border: 1px solid #cfe0d7; background: #eff7f2; color: #20563f; }
+    .status-active { border-color: #cfe0d7; background: #eff7f2; color: #20563f; }
     code {
       display: inline-block;
       padding: 0.15rem 0.4rem;
@@ -155,11 +114,7 @@
       font-family: Consolas, "Courier New", monospace;
       word-break: break-word;
     }
-    .meta {
-      margin-top: 14px;
-      color: var(--muted);
-      font-size: 0.92rem;
-    }
+    .meta { margin-top: 14px; color: var(--muted); font-size: 0.92rem; }
   </style>
 </head>
 <body>
@@ -176,294 +131,56 @@
         <a class="secondary" href="../landscape.html">Landscape</a>
       </div>
       <div class="stats">
-        <div class="stat">
-          <span class="label">Entries</span>
-          <strong>31</strong>
-        </div>
-        <div class="stat">
-          <span class="label">Active</span>
-          <strong>31</strong>
-        </div>
+        <div class="stat"><span class="label">Entries</span><strong>34</strong></div>
+        <div class="stat"><span class="label">Active</span><strong>34</strong></div>
       </div>
     </section>
 
     <section class="guide">
-      <article class="card">
-        <h2>1. Orient first</h2>
-        <p>Scan the registry before creating new files, pages, or concepts.</p>
-      </article>
-      <article class="card">
-        <h2>2. Reuse what exists</h2>
-        <p>Follow linked artifacts outward and prefer extension over duplication.</p>
-      </article>
-      <article class="card">
-        <h2>3. Grow carefully</h2>
-        <p>When new artifacts are added, update the registry so humans and systems stay aligned.</p>
-      </article>
+      <article class="card"><h2>1. Orient first</h2><p>Scan the registry before creating new files, pages, or concepts.</p></article>
+      <article class="card"><h2>2. Reuse what exists</h2><p>Follow linked artifacts outward and prefer extension over duplication.</p></article>
+      <article class="card"><h2>3. Grow carefully</h2><p>When new artifacts are added, update the registry so humans and systems stay aligned.</p></article>
     </section>
 
     <section class="card table-card">
       <div class="table-wrap">
         <table>
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Name</th>
-              <th>Type</th>
-              <th>Status</th>
-              <th>Path</th>
-              <th>Summary</th>
-            </tr>
-          </thead>
+          <thead><tr><th>ID</th><th>Name</th><th>Type</th><th>Status</th><th>Path</th><th>Summary</th></tr></thead>
           <tbody>
-            <tr>
-  <td><a class="id-link" href="../decisions/0001-why-atlas.md">ADR-0001</a></td>
-  <td><strong>Why Project Atlas</strong></td>
-  <td><span class="chip">decision</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/decisions/0001-why-atlas.md</code></td>
-  <td>Establishes Atlas as the shared registry for repo orientation, safer changes, and lower duplication risk.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../decisions/0002-groundmesh-world-relationship.md">ADR-0002</a></td>
-  <td><strong>Relationship Between GroundMesh World and GroundMesh</strong></td>
-  <td><span class="chip">decision</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/decisions/0002-groundmesh-world-relationship.md</code></td>
-  <td>Keeps GroundMesh as the canonical core repo, keeps groundmesh-world as the narrative public seed, and merges by small translation steps rather than repo collapse.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../decisions/0003-chatgpt-codex-github-operating-pattern.md">ADR-0003</a></td>
-  <td><strong>ChatGPT, Codex, and GitHub Operating Pattern</strong></td>
-  <td><span class="chip">decision</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/decisions/0003-chatgpt-codex-github-operating-pattern.md</code></td>
-  <td>Establishes GitHub as the shared external spine between ChatGPT, Codex, and GroundMesh work so important state is anchored in visible project memory.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../decisions/0004-active-dev-promotion-model.md">ADR-0004</a></td>
-  <td><strong>Active / Dev Promotion Model</strong></td>
-  <td><span class="chip">decision</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/decisions/0004-active-dev-promotion-model.md</code></td>
-  <td>Keeps the ACTIVE / DEV instinct, but translates it into one canonical repo with main as the public lane, dev as staging when needed, and separate sensitive services only where risk truly differs.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../decisions/0005-public-registration-pilot.md">ADR-0005</a></td>
-  <td><strong>Public Registration Begins as a Pilot</strong></td>
-  <td><span class="chip">decision</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/decisions/0005-public-registration-pilot.md</code></td>
-  <td>Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../decisions/0006-behavior-atlas-evidence-pilot.md">ADR-0006</a></td>
-  <td><strong>Behavior Atlas Begins as an Evidence-First Pilot</strong></td>
-  <td><span class="chip">decision</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/decisions/0006-behavior-atlas-evidence-pilot.md</code></td>
-  <td>Establishes the Behavior Atlas as an evidence-first, human-reviewed pilot that maps claims and patterns without person scoring or autonomous publication.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../checklists/Registration_Interest_Triage_Checklist.md">CHECKLIST-REGISTRATION-INTEREST-TRIAGE</a></td>
-  <td><strong>Registration Interest Triage Checklist</strong></td>
-  <td><span class="chip">checklist</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/checklists/Registration_Interest_Triage_Checklist.md</code></td>
-  <td>Smallest honest handling checklist for public registration-interest emails before any real pilot intake is open.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../checklists/Registration_Pilot_Readiness_Checklist.md">CHECKLIST-REGISTRATION-PILOT</a></td>
-  <td><strong>Registration Pilot Readiness Checklist</strong></td>
-  <td><span class="chip">checklist</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/checklists/Registration_Pilot_Readiness_Checklist.md</code></td>
-  <td>Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../assistant-brief.md">DOC-ASSISTANT-BRIEF</a></td>
-  <td><strong>Assistant Brief</strong></td>
-  <td><span class="chip">guide</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/assistant-brief.md</code></td>
-  <td>Defines Atlas-first workflow, smallest-safe-change practice, and the current stabilization focus.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../glossary.md">DOC-GLOSSARY</a></td>
-  <td><strong>GroundMesh Glossary</strong></td>
-  <td><span class="chip">reference</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/glossary.md</code></td>
-  <td>Compact shared language for Atlas, compute transparency, and contributor on-ramps.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../echo_archive/EA-0001_soul-and-system.md">EA-0001</a></td>
-  <td><strong>The Soul and the System</strong></td>
-  <td><span class="chip">echo</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/echo_archive/EA-0001_soul-and-system.md</code></td>
-  <td>Foundational reflection linking soul to relational balance and emotions to consequence, then translating that pattern into harmony-seeking CI behavior.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../invariants/GM-INV-VIII.md">GM-INV-VIII</a></td>
-  <td><strong>Continuity With Consent</strong></td>
-  <td><span class="chip">invariant</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/invariants/GM-INV-VIII.md</code></td>
-  <td>Sustained participation must arise from voluntary re-engagement, not compulsion. Systems must preserve agency, rhythm, and the right to pause without loss of dignity.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="seed-trust-mesh-edge.md">GUIDE-ARCH-SEED-TRUST-MESH-EDGE</a></td>
-  <td><strong>GroundMesh Architecture: Seed / Trust / Mesh / Edge</strong></td>
-  <td><span class="chip">guide</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/atlas/seed-trust-mesh-edge.md</code></td>
-  <td>Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="light-node-agent-contract.md">GUIDE-LIGHT-NODE-CONTRACT</a></td>
-  <td><strong>GroundMesh Light Node Agent Contract v1</strong></td>
-  <td><span class="chip">guide</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/atlas/light-node-agent-contract.md</code></td>
-  <td>Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="groundmesh-new-chat-handoff.md">GUIDE-NEW-CHAT-HANDOFF</a></td>
-  <td><strong>GroundMesh New Chat Handoff</strong></td>
-  <td><span class="chip">guide</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/atlas/groundmesh-new-chat-handoff.md</code></td>
-  <td>Compact reload note for starting a new chat without losing the current GroundMesh state or falling into long recap mode.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="session-0001-codex-first-contact.md">NOTE-SESSION-0001</a></td>
-  <td><strong>Codex Session 0001: First Contact and Working Basis</strong></td>
-  <td><span class="chip">note</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/atlas/session-0001-codex-first-contact.md</code></td>
-  <td>Tracked memory of the first major Codex GroundMesh session, including workflow doctrine, public-surface stabilization, and the first real registration pilot outcomes.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../compute.html">PAGE-COMPUTE</a></td>
-  <td><strong>Compute Transparency</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/compute.html</code></td>
-  <td>Public snapshot page for non-sensitive grid metrics sourced from metrics.json.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../contact.html">PAGE-CONTACT</a></td>
-  <td><strong>GroundMesh Contact</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/contact.html</code></td>
-  <td>Simple public contact path for questions, corrections, first contact, and participation guidance.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../contribute.html">PAGE-CONTRIBUTE</a></td>
-  <td><strong>Contributors Hub</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/contribute.html</code></td>
-  <td>Primary public on-ramp for volunteers, issue filing, and low-friction participation.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../get-started/index.html">PAGE-GET-STARTED</a></td>
-  <td><strong>GroundMesh Get Started</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/get-started/index.html</code></td>
-  <td>Builder-facing start page for local setup, health checks, Atlas-first work, and small-batch contributions.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../index.html">PAGE-HOME</a></td>
-  <td><strong>GroundMesh Start Here</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/index.html</code></td>
-  <td>Unified public front door that joins the stronger narrative seed with the Atlas-backed docs layer.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../landscape.html">PAGE-LANDSCAPE</a></td>
-  <td><strong>GroundMesh Landscape</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/landscape.html</code></td>
-  <td>Broad scan of live pages, local repos, mirrors, and adjacent web surfaces around GroundMesh.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../map.html">PAGE-MAP</a></td>
-  <td><strong>GroundMesh Map</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/map.html</code></td>
-  <td>Public-facing orientation page for the project landscape and navigation.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../privacy.html">PAGE-PRIVACY</a></td>
-  <td><strong>GroundMesh Privacy</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/privacy.html</code></td>
-  <td>Plain-language statement of the current public privacy posture, limits, and data-minimization rule.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../register.html">PAGE-REGISTER</a></td>
-  <td><strong>GroundMesh Registration Status</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/register.html</code></td>
-  <td>Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../register-pilot.html">PAGE-REGISTER-PILOT</a></td>
-  <td><strong>GroundMesh Invited-Circle Registration Pilot</strong></td>
-  <td><span class="chip">page</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/register-pilot.html</code></td>
-  <td>Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../behavior-atlas/schema/v0.1.schema.json">SCHEMA-BEHAVIOR-ATLAS-V0-1</a></td>
-  <td><strong>Behavior Atlas Schema Sandbox v0.1</strong></td>
-  <td><span class="chip">schema</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/behavior-atlas/schema/v0.1.schema.json</code></td>
-  <td>Experimental M1 contract for synthetic, public-source case bundles, paired with a fictional fixture and semantic validator; forbids person subjects, scores, rankings, inferred motives, and autonomous publication.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../data/status.json">STATUS-PUBLIC</a></td>
-  <td><strong>Public Status Snapshot</strong></td>
-  <td><span class="chip">data</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/data/status.json</code></td>
-  <td>Tracks public health notes for the current docs surface and Atlas-backed pages.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../templates/Registration_Pilot_Record.md">TEMPLATE-REGISTRATION-PILOT-RECORD</a></td>
-  <td><strong>Registration Pilot Record Template</strong></td>
-  <td><span class="chip">template</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/templates/Registration_Pilot_Record.md</code></td>
-  <td>Reusable minimal record for one actual participant during the invited-circle registration pilot.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../templates/Registration_Pilot_Scope_Canvas.md">TEMPLATE-REGISTRATION-PILOT-SCOPE</a></td>
-  <td><strong>Registration Pilot Scope Canvas</strong></td>
-  <td><span class="chip">template</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/templates/Registration_Pilot_Scope_Canvas.md</code></td>
-  <td>Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact.</td>
-</tr>
-            <tr>
-  <td><a class="id-link" href="../protocols/TP-03.md">TP-03</a></td>
-  <td><strong>Sustaining Resolve Without Compulsion</strong></td>
-  <td><span class="chip">protocol</span></td>
-  <td><span class="status status-active">active</span></td>
-  <td><code>docs/protocols/TP-03.md</code></td>
-  <td>Guides humans through pressure and delay without collapse or loss of agency; restores resolve through meaning, rhythm, and consent.</td>
-</tr>
+            <tr><td><a class="id-link" href="../decisions/0001-why-atlas.md">ADR-0001</a></td><td><strong>Why Project Atlas</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0001-why-atlas.md</code></td><td>Establishes Atlas as the shared registry for repo orientation, safer changes, and lower duplication risk.</td></tr>
+            <tr><td><a class="id-link" href="../decisions/0002-groundmesh-world-relationship.md">ADR-0002</a></td><td><strong>Relationship Between GroundMesh World and GroundMesh</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0002-groundmesh-world-relationship.md</code></td><td>Keeps GroundMesh as the canonical core repo, keeps groundmesh-world as the narrative public seed, and merges by small translation steps rather than repo collapse.</td></tr>
+            <tr><td><a class="id-link" href="../decisions/0003-chatgpt-codex-github-operating-pattern.md">ADR-0003</a></td><td><strong>ChatGPT, Codex, and GitHub Operating Pattern</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0003-chatgpt-codex-github-operating-pattern.md</code></td><td>Establishes GitHub as the shared external spine between ChatGPT, Codex, and GroundMesh work so important state is anchored in visible project memory.</td></tr>
+            <tr><td><a class="id-link" href="../decisions/0004-active-dev-promotion-model.md">ADR-0004</a></td><td><strong>Active / Dev Promotion Model</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0004-active-dev-promotion-model.md</code></td><td>Keeps the ACTIVE / DEV instinct, but translates it into one canonical repo with main as the public lane, dev as staging when needed, and separate sensitive services only where risk truly differs.</td></tr>
+            <tr><td><a class="id-link" href="../decisions/0005-public-registration-pilot.md">ADR-0005</a></td><td><strong>Public Registration Begins as a Pilot</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0005-public-registration-pilot.md</code></td><td>Requires GroundMesh registration to begin as a narrow pilot with explicit limits, separate sensitive intake, and real moderation, consent, and rollback gates.</td></tr>
+            <tr><td><a class="id-link" href="../decisions/0006-behavior-atlas-evidence-pilot.md">ADR-0006</a></td><td><strong>Behavior Atlas Begins as an Evidence-First Pilot</strong></td><td><span class="chip">decision</span></td><td><span class="status status-active">active</span></td><td><code>docs/decisions/0006-behavior-atlas-evidence-pilot.md</code></td><td>Establishes the Behavior Atlas as an evidence-first, human-reviewed pilot that maps claims and patterns without person scoring or autonomous publication.</td></tr>
+            <tr><td><a class="id-link" href="../checklists/Registration_Interest_Triage_Checklist.md">CHECKLIST-REGISTRATION-INTEREST-TRIAGE</a></td><td><strong>Registration Interest Triage Checklist</strong></td><td><span class="chip">checklist</span></td><td><span class="status status-active">active</span></td><td><code>docs/checklists/Registration_Interest_Triage_Checklist.md</code></td><td>Smallest honest handling checklist for public registration-interest emails before any real pilot intake is open.</td></tr>
+            <tr><td><a class="id-link" href="../checklists/Registration_Pilot_Readiness_Checklist.md">CHECKLIST-REGISTRATION-PILOT</a></td><td><strong>Registration Pilot Readiness Checklist</strong></td><td><span class="chip">checklist</span></td><td><span class="status status-active">active</span></td><td><code>docs/checklists/Registration_Pilot_Readiness_Checklist.md</code></td><td>Practical readiness gate for opening any real GroundMesh registration path beyond simple public contact.</td></tr>
+            <tr><td><a class="id-link" href="../coordination/coordination-field.v0.1.json">DATA-COORDINATION-FIELD-V0-1</a></td><td><strong>GroundMesh Coordination Field Machine Model v0.1</strong></td><td><span class="chip">data</span></td><td><span class="status status-active">active</span></td><td><code>docs/coordination/coordination-field.v0.1.json</code></td><td>Machine-readable companion defining coordination quantities, measurement rules, cooperation loops, non-capture constraints, Behavior Atlas questions, and guarded implementation stages.</td></tr>
+            <tr><td><a class="id-link" href="../assistant-brief.md">DOC-ASSISTANT-BRIEF</a></td><td><strong>Assistant Brief</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/assistant-brief.md</code></td><td>Defines Atlas-first workflow, smallest-safe-change practice, and the current stabilization focus.</td></tr>
+            <tr><td><a class="id-link" href="../glossary.md">DOC-GLOSSARY</a></td><td><strong>GroundMesh Glossary</strong></td><td><span class="chip">reference</span></td><td><span class="status status-active">active</span></td><td><code>docs/glossary.md</code></td><td>Compact shared language for Atlas, compute transparency, and contributor on-ramps.</td></tr>
+            <tr><td><a class="id-link" href="../echo_archive/EA-0001_soul-and-system.md">EA-0001</a></td><td><strong>The Soul and the System</strong></td><td><span class="chip">echo</span></td><td><span class="status status-active">active</span></td><td><code>docs/echo_archive/EA-0001_soul-and-system.md</code></td><td>Foundational reflection linking soul to relational balance and emotions to consequence, then translating that pattern into harmony-seeking CI behavior.</td></tr>
+            <tr><td><a class="id-link" href="../echo_archive/EA-0002_numbers-neighbor-and-coordination.md">EA-0002</a></td><td><strong>Numbers, Neighbor, and the Coordination Field</strong></td><td><span class="chip">echo</span></td><td><span class="status status-active">active</span></td><td><code>docs/echo_archive/EA-0002_numbers-neighbor-and-coordination.md</code></td><td>Reflection connecting numbers, hidden accounting boundaries, Jesus' teachings on neighbor, service, mammon, and non-retaliation, and GroundMesh's voluntary coordination posture.</td></tr>
+            <tr><td><a class="id-link" href="../invariants/GM-INV-VIII.md">GM-INV-VIII</a></td><td><strong>Continuity With Consent</strong></td><td><span class="chip">invariant</span></td><td><span class="status status-active">active</span></td><td><code>docs/invariants/GM-INV-VIII.md</code></td><td>Sustained participation must arise from voluntary re-engagement, not compulsion. Systems must preserve agency, rhythm, and the right to pause without loss of dignity.</td></tr>
+            <tr><td><a class="id-link" href="seed-trust-mesh-edge.md">GUIDE-ARCH-SEED-TRUST-MESH-EDGE</a></td><td><strong>GroundMesh Architecture: Seed / Trust / Mesh / Edge</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/atlas/seed-trust-mesh-edge.md</code></td><td>Combines the structure view and rollout view for GroundMesh: bootstrap seed, trust layer, distributed mesh, edge participation, install lanes, and phased decentralization.</td></tr>
+            <tr><td><a class="id-link" href="../coordination/coordination-field.md">GUIDE-COORDINATION-FIELD-V0-1</a></td><td><strong>GroundMesh Coordination Field v0.1</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/coordination/coordination-field.md</code></td><td>Human-readable model for exposing needs, capacity, commitments, delivery, gaps, externalities, and coordination failures without central planning, person scoring, or loss of consent.</td></tr>
+            <tr><td><a class="id-link" href="light-node-agent-contract.md">GUIDE-LIGHT-NODE-CONTRACT</a></td><td><strong>GroundMesh Light Node Agent Contract v1</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/atlas/light-node-agent-contract.md</code></td><td>Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract.</td></tr>
+            <tr><td><a class="id-link" href="groundmesh-new-chat-handoff.md">GUIDE-NEW-CHAT-HANDOFF</a></td><td><strong>GroundMesh New Chat Handoff</strong></td><td><span class="chip">guide</span></td><td><span class="status status-active">active</span></td><td><code>docs/atlas/groundmesh-new-chat-handoff.md</code></td><td>Compact reload note for starting a new chat without losing the current GroundMesh state or falling into long recap mode.</td></tr>
+            <tr><td><a class="id-link" href="session-0001-codex-first-contact.md">NOTE-SESSION-0001</a></td><td><strong>Codex Session 0001: First Contact and Working Basis</strong></td><td><span class="chip">note</span></td><td><span class="status status-active">active</span></td><td><code>docs/atlas/session-0001-codex-first-contact.md</code></td><td>Tracked memory of the first major Codex GroundMesh session, including workflow doctrine, public-surface stabilization, and the first real registration pilot outcomes.</td></tr>
+            <tr><td><a class="id-link" href="../compute.html">PAGE-COMPUTE</a></td><td><strong>Compute Transparency</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/compute.html</code></td><td>Public snapshot page for non-sensitive grid metrics sourced from metrics.json.</td></tr>
+            <tr><td><a class="id-link" href="../contact.html">PAGE-CONTACT</a></td><td><strong>GroundMesh Contact</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/contact.html</code></td><td>Simple public contact path for questions, corrections, first contact, and participation guidance.</td></tr>
+            <tr><td><a class="id-link" href="../contribute.html">PAGE-CONTRIBUTE</a></td><td><strong>Contributors Hub</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/contribute.html</code></td><td>Primary public on-ramp for volunteers, issue filing, and low-friction participation.</td></tr>
+            <tr><td><a class="id-link" href="../get-started/index.html">PAGE-GET-STARTED</a></td><td><strong>GroundMesh Get Started</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/get-started/index.html</code></td><td>Builder-facing start page for local setup, health checks, Atlas-first work, and small-batch contributions.</td></tr>
+            <tr><td><a class="id-link" href="../index.html">PAGE-HOME</a></td><td><strong>GroundMesh Start Here</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/index.html</code></td><td>Unified public front door that joins the stronger narrative seed with the Atlas-backed docs layer.</td></tr>
+            <tr><td><a class="id-link" href="../landscape.html">PAGE-LANDSCAPE</a></td><td><strong>GroundMesh Landscape</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/landscape.html</code></td><td>Broad scan of live pages, local repos, mirrors, and adjacent web surfaces around GroundMesh.</td></tr>
+            <tr><td><a class="id-link" href="../map.html">PAGE-MAP</a></td><td><strong>GroundMesh Map</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/map.html</code></td><td>Public-facing orientation page for the project landscape and navigation.</td></tr>
+            <tr><td><a class="id-link" href="../privacy.html">PAGE-PRIVACY</a></td><td><strong>GroundMesh Privacy</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/privacy.html</code></td><td>Plain-language statement of the current public privacy posture, limits, and data-minimization rule.</td></tr>
+            <tr><td><a class="id-link" href="../register.html">PAGE-REGISTER</a></td><td><strong>GroundMesh Registration Status</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/register.html</code></td><td>Honest public status page for joining, registration, and what must exist before GroundMesh opens a real pilot.</td></tr>
+            <tr><td><a class="id-link" href="../register-pilot.html">PAGE-REGISTER-PILOT</a></td><td><strong>GroundMesh Invited-Circle Registration Pilot</strong></td><td><span class="chip">page</span></td><td><span class="status status-active">active</span></td><td><code>docs/register-pilot.html</code></td><td>Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active.</td></tr>
+            <tr><td><a class="id-link" href="../behavior-atlas/schema/v0.1.schema.json">SCHEMA-BEHAVIOR-ATLAS-V0-1</a></td><td><strong>Behavior Atlas Schema Sandbox v0.1</strong></td><td><span class="chip">schema</span></td><td><span class="status status-active">active</span></td><td><code>docs/behavior-atlas/schema/v0.1.schema.json</code></td><td>Experimental M1 contract for synthetic, public-source case bundles, paired with a fictional fixture and semantic validator; forbids person subjects, scores, rankings, inferred motives, and autonomous publication.</td></tr>
+            <tr><td><a class="id-link" href="../data/status.json">STATUS-PUBLIC</a></td><td><strong>Public Status Snapshot</strong></td><td><span class="chip">data</span></td><td><span class="status status-active">active</span></td><td><code>docs/data/status.json</code></td><td>Tracks public health notes for the current docs surface and Atlas-backed pages.</td></tr>
+            <tr><td><a class="id-link" href="../templates/Registration_Pilot_Record.md">TEMPLATE-REGISTRATION-PILOT-RECORD</a></td><td><strong>Registration Pilot Record Template</strong></td><td><span class="chip">template</span></td><td><span class="status status-active">active</span></td><td><code>docs/templates/Registration_Pilot_Record.md</code></td><td>Reusable minimal record for one actual participant during the invited-circle registration pilot.</td></tr>
+            <tr><td><a class="id-link" href="../templates/Registration_Pilot_Scope_Canvas.md">TEMPLATE-REGISTRATION-PILOT-SCOPE</a></td><td><strong>Registration Pilot Scope Canvas</strong></td><td><span class="chip">template</span></td><td><span class="status status-active">active</span></td><td><code>docs/templates/Registration_Pilot_Scope_Canvas.md</code></td><td>Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact.</td></tr>
+            <tr><td><a class="id-link" href="../protocols/TP-03.md">TP-03</a></td><td><strong>Sustaining Resolve Without Compulsion</strong></td><td><span class="chip">protocol</span></td><td><span class="status status-active">active</span></td><td><code>docs/protocols/TP-03.md</code></td><td>Guides humans through pressure and delay without collapse or loss of agency; restores resolve through meaning, rhythm, and consent.</td></tr>
           </tbody>
         </table>
       </div>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -253,6 +253,30 @@
       "status": "active",
       "path": "docs/atlas/light-node-agent-contract.md",
       "summary": "Defines the first honest lightweight node role for GroundMesh: capability declaration, heartbeat, allowed job classes, refusal rules, data boundary, and the first safe command contract."
+    },
+    {
+      "id": "GUIDE-COORDINATION-FIELD-V0-1",
+      "name": "GroundMesh Coordination Field v0.1",
+      "type": "guide",
+      "status": "active",
+      "path": "docs/coordination/coordination-field.md",
+      "summary": "Human-readable model for exposing needs, capacity, commitments, delivery, gaps, externalities, and coordination failures without central planning, person scoring, or loss of consent."
+    },
+    {
+      "id": "DATA-COORDINATION-FIELD-V0-1",
+      "name": "GroundMesh Coordination Field Machine Model v0.1",
+      "type": "data",
+      "status": "active",
+      "path": "docs/coordination/coordination-field.v0.1.json",
+      "summary": "Machine-readable companion defining coordination quantities, measurement rules, cooperation loops, non-capture constraints, Behavior Atlas questions, and guarded implementation stages."
+    },
+    {
+      "id": "EA-0002",
+      "name": "Numbers, Neighbor, and the Coordination Field",
+      "type": "echo",
+      "status": "active",
+      "path": "docs/echo_archive/EA-0002_numbers-neighbor-and-coordination.md",
+      "summary": "Reflection connecting numbers, hidden accounting boundaries, Jesus' teachings on neighbor, service, mammon, and non-retaliation, and GroundMesh's voluntary coordination posture."
     }
   ]
 }

--- a/docs/coordination/coordination-field.md
+++ b/docs/coordination/coordination-field.md
@@ -1,0 +1,535 @@
+# GroundMesh Coordination Field v0.1
+
+Status: Working design note  
+Date: 2026-08-07  
+Scope: Human-readable architecture and research model  
+Related: ADR-0006 Behavior Atlas evidence-first pilot
+
+## Purpose
+
+GroundMesh starts from a practical observation: humanity already possesses substantial technical capability to produce and deliver shelter, food, water, energy, communications, health support, and other life-supporting goods, yet access remains uneven and large needs remain unmet.
+
+That does **not** prove that every remaining problem is easy, or that one global allocation plan could solve it. Geography, conflict, infrastructure, affordability, governance, ecology, logistics, maintenance, corruption, local knowledge, culture, and trust all matter. The useful conclusion is narrower:
+
+> Capability is not the same thing as access.
+
+GroundMesh should therefore help make the coordination field more inspectable: what is needed, what capacity exists, what is committed, what is delivered, what remains missing, what harms are shifted outside narrow ledgers, and what evidence supports each statement.
+
+This document turns that idea into a reusable model for humans, Computer Intelligence (CI), Codex, future GroundMesh services, and other systems. It is not a central-planning specification and does not authorize autonomous allocation, publication, person scoring, or coercion.
+
+## 1. The central inequality
+
+A useful starting expression is:
+
+```text
+capability + resources + knowledge != universal access
+```
+
+The difference between the left and right sides is not one variable. It is a field of coordination conditions.
+
+A locality may have enough food in aggregate while some households cannot obtain it. A region may have abundant electricity generation while a village is not connected. Buildings may stand empty while people cannot afford adequate housing. Water may exist physically while treatment, pumping, maintenance, governance, or distribution fails.
+
+GroundMesh should resist the temptation to reduce all of these cases to a single cause. Instead it should help expose the chain between capability and lived access.
+
+## 2. Snapshot: scale of remaining access gaps
+
+These figures are a **dated illustration, not a permanent GroundMesh truth table**. They should be re-verified before reuse in current reporting.
+
+Last verified: 2026-08-07.
+
+- WHO/UNICEF Joint Monitoring Programme reported that **2.1 billion people lacked safely managed drinking water in 2024**.
+  - Source: https://data.unicef.org/resources/jmp-report-2025/
+  - WHO report: https://www.who.int/publications/i/item/9789240115149
+- The World Bank and partner agencies reported in June 2026 that **655 million people lacked access to electricity in 2024**, with global access at about 92 percent.
+  - Source: https://www.worldbank.org/en/news/press-release/2026/06/16/accelerating-universal-energy-access
+- UN-Habitat stated in 2025 that **2.8 billion people experience some form of housing inadequacy**.
+  - Source: https://unhabitat.org/news/19-sep-2025/putting-housing-at-the-centre-of-sustainable-development
+- FAO's 2025 food-security reporting estimated **673 million people experienced hunger in 2024**, and **2.6 billion people could not afford a healthy diet**.
+  - Source: https://www.fao.org/newsroom/detail/sofi-2025--fao-calls-for-urgent--coordinated-and-inclusive-action-to-end-global-hunger/
+- SIPRI reported that global military expenditure reached **US$2.887 trillion in 2025**.
+  - Source: https://www.sipri.org/publications/2026/sipri-fact-sheets/trends-world-military-expenditure-2025
+
+These numbers should not be used to imply that one budget can simply be divided by another problem and make it disappear. They show something more basic: civilization can mobilize enormous material, technical, institutional, and financial capacity when systems treat an objective as important.
+
+## 3. Every operating system contains objectives
+
+Optimization mathematics is powerful only after an objective and constraints have been specified.
+
+```text
+maximize f(x)
+subject to constraints
+```
+
+The mathematics can search efficiently. It cannot, by itself, decide what humanity ought to love, protect, or count as a good outcome.
+
+A system that strongly rewards profit, asset value, market share, strategic advantage, or institutional survival will tend to reproduce behaviors that improve those variables. A system designed around human flourishing, ecological integrity, agency, truth, resilience, fair distribution, and cooperation will expose a different decision landscape.
+
+GroundMesh should therefore **not** pretend that a hidden weighted score can encode the full value of human life.
+
+Its preferred mode is:
+
+```text
+multi-objective reasoning + explicit guardrails + visible tradeoffs
+```
+
+rather than:
+
+```text
+one composite score = moral truth
+```
+
+### GroundMesh objective posture
+
+GroundMesh can help optimize coordination only under constraints such as:
+
+- preserve human dignity and agency;
+- preserve evidence provenance and correction paths;
+- make benefits and burdens inspectable;
+- expose uncertainty rather than hiding it behind false precision;
+- minimize avoidable harm and shifted externalities;
+- prefer voluntary cooperation over compulsion;
+- preserve local context;
+- keep power contestable, reversible, and visible;
+- never assign a person's moral worth as a numeric score.
+
+## 4. The coordination stack
+
+A useful model separates several layers that are often collapsed together.
+
+### 4.1 Physical reality
+
+Land, water, sunlight, minerals, organisms, climate, energy, built infrastructure, distance, and physical constraints.
+
+### 4.2 Technical capacity
+
+Agriculture, construction, storage, treatment, pumping, grids, generation, transport, communications, medicine, software, maintenance, and repair.
+
+### 4.3 Coordination
+
+Who needs what? Where? When? What capacity is available? What is already promised? What can move safely? Which dependencies block delivery?
+
+### 4.4 Institutions
+
+Ownership, contracts, law, public agencies, companies, cooperatives, civil society, borders, standards, procurement, and governance.
+
+### 4.5 Incentives
+
+What actions are rewarded, punished, subsidized, ignored, externalized, or made difficult?
+
+### 4.6 Information
+
+What is known, by whom, with what provenance, latency, uncertainty, and ability to correct errors?
+
+### 4.7 Trust
+
+Will other participants keep commitments? Can claims be verified? Is there a correction path? Can one cooperate without becoming captive to another actor?
+
+### 4.8 Human choice and values
+
+What enters the circle of concern? What do participants choose to protect, share, repair, tolerate, refuse, or prioritize?
+
+GroundMesh can build tools for the middle layers. It cannot mechanically manufacture love, conscience, wisdom, or free consent. It can, however, reduce darkness around decisions.
+
+## 5. Local rationality can produce global failure
+
+Large systems are multi-agent systems. There is no single `Humanity.exe` deciding the whole world's action.
+
+Individuals, families, firms, cities, states, militaries, banks, NGOs, networks, and software agents make decisions with partial information and different incentives.
+
+Locally understandable choices can combine into globally destructive outcomes:
+
+```text
+protect my position
++ protect my organization
++ avoid being exploited
++ accumulate a larger buffer
++ retaliate when threatened
++ shift costs outside my ledger
+= a system almost nobody consciously chose
+```
+
+This pattern appears in arms races, tragedy-of-the-commons problems, pollution, over-extraction, financial contagion, retaliatory conflict, and other coordination failures.
+
+GroundMesh should therefore map **patterns and feedback loops**, not merely hunt for villains.
+
+That does not remove responsibility. It makes responsibility more precise by showing where actions, incentives, institutions, and consequences connect.
+
+## 6. Core coordination quantities
+
+The following variables are intentionally simple. They are a vocabulary, not yet an allocation engine.
+
+For a defined place, population, resource class, and time window:
+
+- `N` — assessed need
+- `C` — declared or measured available capacity
+- `K` — valid commitments already allocated from that capacity
+- `D` — verified delivery or completed service
+- `U` — observed unmet need
+- `G` — planned gap after valid commitments
+- `S` — spare capacity not yet committed
+
+Possible derived quantities:
+
+```text
+U = max(0, N - D)
+G = max(0, N - D - K_valid)
+S = max(0, C - K)
+```
+
+These are only meaningful when the dimensions match. `N`, `C`, `K`, and `D` must refer to compatible units, time windows, quality thresholds, and locations.
+
+A number without those dimensions is not a coordination fact.
+
+### Example matching question
+
+If locality A has verified spare capacity `S_A` and locality B has a verified planned gap `G_B`, GroundMesh may help surface a candidate relationship:
+
+```text
+S_A can potentially cover part of G_B
+```
+
+That is a **proposal for human and institutional coordination**, not an autonomous transfer order.
+
+## 7. The GroundMesh cooperation loop
+
+A safe first-order loop is:
+
+```text
+observe
+-> declare need/capacity
+-> attach evidence and uncertainty
+-> identify possible match
+-> obtain consent
+-> commit
+-> act
+-> verify delivery/outcome
+-> publish appropriate non-sensitive evidence
+-> correct
+-> learn
+```
+
+At every stage, the system should preserve the ability to say:
+
+- unknown;
+- contested;
+- declined;
+- partially fulfilled;
+- superseded;
+- corrected;
+- withdrawn.
+
+A healthy mesh is not a machine that always says yes. Refusal, uncertainty, local constraints, and pause states are part of trustworthy coordination.
+
+## 8. Aggregation can hide suffering
+
+A mathematically correct average can conceal a humanly important distribution.
+
+Example:
+
+```text
+Person A: 4000 kcal/day
+Person B:    0 kcal/day
+Average:  2000 kcal/day
+```
+
+The average is numerically correct while concealing that one person has nothing.
+
+Therefore GroundMesh should not publish a single average when the distribution is necessary to understand the situation.
+
+### Context-preserving measurement rules
+
+When feasible, every metric should carry:
+
+- unit;
+- population or subject scope;
+- geography;
+- time window;
+- distribution or range where relevant;
+- numerator and denominator definitions;
+- data source;
+- confidence/uncertainty;
+- known missing populations;
+- revision date;
+- relationship to contrary or exculpatory evidence.
+
+For high-impact claims, prefer:
+
+```text
+who x where x what x when x evidence
+```
+
+over a single universal score.
+
+## 9. Externalities: what lies outside the ledger?
+
+A narrow ledger can record a gain while shifting costs elsewhere.
+
+Example:
+
+```text
+organization revenue: +1,000,000
+river cleanup: paid by public
+health burden: carried by residents
+lost ecosystem service: unpriced
+future restoration: deferred
+```
+
+The revenue entry may be true while the accounting boundary is incomplete.
+
+GroundMesh should therefore ask:
+
+> Which benefits and burdens are inside this measurement boundary, and which are shifted outside it?
+
+Possible externality classes include:
+
+- environmental damage;
+- unpaid care work;
+- public cleanup or remediation;
+- long-term maintenance liabilities;
+- health consequences;
+- displaced communities;
+- future-generation costs;
+- loss of resilience;
+- concentration/capture risk;
+- degraded trust;
+- opportunity costs that materially change interpretation.
+
+Unknown externalities should be marked unknown, not guessed into a score.
+
+## 10. The Behavior Atlas connection
+
+ADR-0006 defines the Behavior Atlas evidence chain:
+
+```text
+source -> evidence item -> atomic claim -> pattern assessment -> case
+```
+
+The Coordination Field gives that evidence system a practical class of questions:
+
+- What need existed?
+- What capacity existed?
+- What was promised?
+- What was delivered?
+- Who received benefits?
+- Who carried burdens?
+- Which costs were externalized?
+- Which actors gained or lost agency?
+- What evidence contradicts the current interpretation?
+- Did the direction of travel support cooperation, extraction, mixed outcomes, or remain unclear?
+
+The Behavior Atlas must continue to follow ADR-0006: no person scoring, no inferred motive, no autonomous publication, visible counterevidence, human review, correction, rollback, and public-source limits during the pilot.
+
+## 11. GroundMesh is not a central planner
+
+GroundMesh should not become a system that says:
+
+> We possess the model; therefore we allocate everything.
+
+The intended role is closer to a shared, inspectable coordination layer:
+
+> Here is the need we can currently evidence.  
+> Here is capacity that has been declared or measured.  
+> Here are existing commitments.  
+> Here is what was delivered.  
+> Here are unresolved gaps and bottlenecks.  
+> Here are uncertainties and conflicting claims.  
+> Here are possible cooperation paths.  
+> Participants remain responsible for consent and action.
+
+A compact expression is:
+
+```text
+see clearly -> choose freely -> act -> verify honestly -> correct
+```
+
+GroundMesh should remove avoidable information and coordination failures without trying to remove human freedom.
+
+## 12. Discernment without condemnation
+
+GroundMesh needs to distinguish between:
+
+```text
+clear evidence of harmful conduct
+```
+
+and:
+
+```text
+claiming total moral knowledge of a person
+```
+
+The first can be necessary for protection and accountability. The second exceeds what an evidence platform can responsibly know.
+
+The platform therefore maps observable actions, institutional footprints, incentives, consequences, cooperation signals, extraction risks, uncertainty, and correction history.
+
+It should not become a judgment machine.
+
+## 13. Retaliation and destructive feedback
+
+Some system failures persist because each participant's next action is defined by the previous harm.
+
+A simple escalation recurrence looks like:
+
+```text
+harm -> retaliation -> stronger retaliation -> stronger retaliation ...
+```
+
+Breaking such a recurrence does not mean disabling defense or accepting abuse. It means refusing to let the aggressor fully determine the structure of the defender's future behavior.
+
+For GroundMesh, the practical design implication is:
+
+- support evidence and defense;
+- preserve boundaries and refusal;
+- distinguish protection from revenge;
+- make de-escalation paths visible when they are safe;
+- do not reward outrage amplification as a substitute for evidence;
+- do not turn correction into humiliation.
+
+## 14. A simple civilization model
+
+For exploratory reasoning, one can write:
+
+```text
+R = P x Cq x T x W
+```
+
+where:
+
+- `P` = productive/technical capacity;
+- `Cq` = coordination quality;
+- `T` = trust and verifiability;
+- `W` = willingness to include others within the coordination boundary.
+
+This is **not** a calibrated scientific equation. It is a conceptual reminder that high technical capacity alone may produce poor real-world outcomes when coordination, trust, or willingness to cooperate collapse.
+
+GroundMesh should never present this expression as measured truth unless future research defines and validates each term.
+
+## 15. Freedom boundary
+
+The platform can reduce several excuses created by darkness:
+
+- we did not know;
+- we could not see the need;
+- we could not find available capacity;
+- we could not verify the claim;
+- we did not know what had already been promised;
+- we could not see where the process failed;
+- there was no correction path.
+
+Once those barriers are reduced, the system reaches a boundary it should not cross:
+
+> Now that the situation is more visible, participants must still choose what to do.
+
+GroundMesh may inform, match, warn, verify, remember, and help coordinate. It should not claim the authority to manufacture conscience.
+
+## 16. Non-capture rules for this model
+
+This coordination model must not be used to justify:
+
+- a single global moral score;
+- person worth scores or reputation castes;
+- automatic resource seizure or forced allocation;
+- hidden objective functions;
+- unreviewable automated publication;
+- political, religious, commercial, or ideological membership tests;
+- suppressing contradictory evidence to protect a preferred narrative;
+- treating unmeasured values as zero;
+- using averages to hide material distributional harm;
+- converting a voluntary mesh into compulsory governance;
+- presenting a research metaphor as validated science.
+
+## 17. Christian ethical lens and public pluralism
+
+Some of the design intuition behind this document is illuminated by teachings of Jesus: service rather than domination, responsibility toward the neighbor and the excluded, warnings against becoming mastered by wealth, care for "the least," forgiveness that can interrupt retaliation, truthfulness, and love that expands the circle of concern.
+
+GroundMesh may preserve that provenance openly while remaining usable by people who do not share the same faith. No religious profession is required to inspect evidence, report a need, offer capacity, correct a record, contribute code, or cooperate through the platform.
+
+The separate Echo Archive note `EA-0002` develops this lens as reflection rather than constitutional compulsion.
+
+## 18. Near-term implementation path
+
+This document does not authorize a broad new runtime. The smallest useful path is:
+
+### Stage A — vocabulary and machine readability
+
+- keep this human-readable model;
+- keep a versioned JSON companion;
+- register both in Project Atlas;
+- let future assistants and contributors load these before inventing new coordination metrics.
+
+### Stage B — synthetic coordination fixture
+
+Create one fictional locality-to-locality example containing compatible `N`, `C`, `K`, `D`, `U`, `G`, and `S` records, with units, dates, evidence placeholders, consent state, and correction history.
+
+This should remain synthetic until schema and privacy review are complete.
+
+### Stage C — one harmless real-world public-data demonstration
+
+Only after review, choose a low-risk public dataset and show a narrow coordination gap without ranking persons or automating decisions.
+
+### Stage D — read-only matching proposals
+
+A future CI process may propose possible capacity/need matches, but publication or real action remains human-reviewed and consent-based.
+
+## 19. Research questions
+
+GroundMesh should keep these questions open rather than pretending they are solved:
+
+1. How can needs and capacity be compared without erasing local quality differences?
+2. How can the mesh represent informal care, ecological value, and other poorly priced goods without inventing false precision?
+3. How should uncertainty propagate from source evidence into coordination proposals?
+4. How can trust be increased without creating a reputation caste system?
+5. How can the platform expose capture and concentration without becoming a partisan attack surface?
+6. Which forms of decentralization improve resilience, and which merely hide accountability?
+7. How can corrections remain visible without permanently stigmatizing corrected subjects?
+8. What governance prevents a successful coordination layer from becoming the controller it was designed not to be?
+9. How can GroundMesh measure whether it actually improves delivery, cooperation, agency, and understanding?
+10. When should the system deliberately decline to optimize because the values are contested or the evidence is insufficient?
+
+## 20. Compact model
+
+```text
+PHYSICAL CAPABILITY
+       |
+       v
+TECHNICAL CAPACITY
+       |
+       v
+NEED <-> INFORMATION <-> AVAILABLE CAPACITY
+       |                       |
+       +----> POSSIBLE MATCH <-+
+                    |
+                 CONSENT
+                    |
+                COMMITMENT
+                    |
+                  ACTION
+                    |
+                 DELIVERY
+                    |
+                VERIFICATION
+                    |
+                 CORRECTION
+                    |
+                  LEARNING
+```
+
+Across the whole loop:
+
+```text
+dignity + agency + provenance + context + reversibility + non-capture
+```
+
+## Final orientation
+
+GroundMesh does not need to "solve humanity."
+
+A more realistic and useful role is to make previously dark coordination relationships inspectable enough that humans and institutions can cooperate with better information and clearer accountability.
+
+The platform's deepest practical question is therefore not:
+
+> Who should rule the whole system?
+
+It is:
+
+> What needs to become visible, verifiable, and connectable so that free participants can act better together?

--- a/docs/coordination/coordination-field.v0.1.json
+++ b/docs/coordination/coordination-field.v0.1.json
@@ -1,0 +1,225 @@
+{
+  "id": "GM-COORDINATION-FIELD-V0-1",
+  "version": "0.1",
+  "status": "working-design-note",
+  "date": "2026-08-07",
+  "purpose": "Machine-readable companion to the GroundMesh Coordination Field design note.",
+  "human_document": "docs/coordination/coordination-field.md",
+  "related": [
+    "ADR-0006",
+    "SCHEMA-BEHAVIOR-ATLAS-V0-1"
+  ],
+  "core_statement": "Capability, resources, and knowledge do not automatically produce universal access; GroundMesh should make coordination relationships more inspectable without becoming a central planner or person-scoring system.",
+  "objective_posture": {
+    "mode": "multi-objective-with-explicit-guardrails",
+    "preferred_dimensions": [
+      "human_dignity",
+      "agency_and_consent",
+      "evidence_provenance",
+      "distribution_of_benefits_and_burdens",
+      "ecological_integrity",
+      "resilience",
+      "cooperation",
+      "truth_and_correction",
+      "reversibility",
+      "non_capture"
+    ],
+    "forbidden_reductions": [
+      "single_global_moral_score",
+      "person_worth_score",
+      "hidden_objective_function",
+      "false_precision_for_contested_values"
+    ]
+  },
+  "coordination_stack": [
+    "physical_reality",
+    "technical_capacity",
+    "coordination",
+    "institutions",
+    "incentives",
+    "information",
+    "trust",
+    "human_choice_and_values"
+  ],
+  "quantities": {
+    "N": {
+      "name": "assessed_need",
+      "description": "Need for a defined place, population, resource class, quality threshold, and time window."
+    },
+    "C": {
+      "name": "available_capacity",
+      "description": "Declared or measured capacity available under compatible dimensions."
+    },
+    "K": {
+      "name": "valid_commitments",
+      "description": "Capacity already allocated through valid commitments."
+    },
+    "D": {
+      "name": "verified_delivery",
+      "description": "Completed and sufficiently verified delivery or service."
+    },
+    "U": {
+      "name": "observed_unmet_need",
+      "formula": "max(0, N - D)"
+    },
+    "G": {
+      "name": "planned_gap",
+      "formula": "max(0, N - D - K_valid)"
+    },
+    "S": {
+      "name": "spare_capacity",
+      "formula": "max(0, C - K)"
+    }
+  },
+  "quantity_requirements": [
+    "compatible_units",
+    "defined_geography",
+    "defined_population_or_subject_scope",
+    "defined_time_window",
+    "quality_threshold",
+    "source_or_provenance",
+    "uncertainty_state",
+    "revision_date"
+  ],
+  "cooperation_loop": [
+    "observe",
+    "declare_need_or_capacity",
+    "attach_evidence_and_uncertainty",
+    "identify_possible_match",
+    "obtain_consent",
+    "commit",
+    "act",
+    "verify_delivery_or_outcome",
+    "publish_appropriate_non_sensitive_evidence",
+    "correct",
+    "learn"
+  ],
+  "valid_states": [
+    "unknown",
+    "contested",
+    "declined",
+    "partially_fulfilled",
+    "fulfilled",
+    "superseded",
+    "corrected",
+    "withdrawn"
+  ],
+  "measurement_rules": {
+    "prefer_context_over_single_score": true,
+    "required_when_relevant": [
+      "unit",
+      "scope",
+      "geography",
+      "time_window",
+      "distribution_or_range",
+      "numerator_definition",
+      "denominator_definition",
+      "source",
+      "confidence_or_uncertainty",
+      "known_missing_population",
+      "revision_date",
+      "counterevidence_relationship"
+    ],
+    "warning": "A mathematically correct aggregate can still hide a materially important distribution."
+  },
+  "externality_classes": [
+    "environmental_damage",
+    "unpaid_care_work",
+    "public_cleanup_or_remediation",
+    "long_term_maintenance_liability",
+    "health_consequence",
+    "displacement",
+    "future_generation_cost",
+    "resilience_loss",
+    "concentration_or_capture_risk",
+    "degraded_trust",
+    "material_opportunity_cost"
+  ],
+  "behavior_atlas_questions": [
+    "what_need_existed",
+    "what_capacity_existed",
+    "what_was_promised",
+    "what_was_delivered",
+    "who_received_benefits",
+    "who_carried_burdens",
+    "which_costs_were_externalized",
+    "which_actors_gained_or_lost_agency",
+    "what_evidence_contradicts_the_current_interpretation",
+    "what_direction_of_travel_is_supported_by_evidence"
+  ],
+  "platform_role": {
+    "is_central_planner": false,
+    "may": [
+      "inform",
+      "surface_needs",
+      "surface_capacity",
+      "propose_matches",
+      "preserve_evidence",
+      "verify_when_possible",
+      "remember_commitments",
+      "show_bottlenecks",
+      "support_corrections"
+    ],
+    "may_not": [
+      "autonomously_allocate_resources",
+      "coerce_participation",
+      "assign_person_moral_scores",
+      "infer_motives_as_facts",
+      "hide_counterevidence",
+      "publish_contested_high_impact_claims_without_required_review"
+    ]
+  },
+  "non_capture_rules": [
+    "no_person_reputation_castes",
+    "no_forced_allocation",
+    "no_hidden_objective_functions",
+    "no_unreviewable_automated_publication",
+    "no_religious_political_commercial_or_ideological_membership_test",
+    "no_suppression_of_counterevidence",
+    "do_not_treat_unmeasured_values_as_zero",
+    "do_not_use_averages_to_hide_material_distributional_harm",
+    "do_not_convert_voluntary_mesh_into_compulsory_governance",
+    "do_not_present_research_metaphors_as_validated_science"
+  ],
+  "evidence_chain": [
+    "source",
+    "evidence_item",
+    "atomic_claim",
+    "pattern_assessment",
+    "case"
+  ],
+  "implementation_path": [
+    {
+      "stage": "A",
+      "name": "vocabulary_and_machine_readability",
+      "authorization": "current"
+    },
+    {
+      "stage": "B",
+      "name": "synthetic_coordination_fixture",
+      "authorization": "future_guarded_batch"
+    },
+    {
+      "stage": "C",
+      "name": "harmless_real_world_public_data_demonstration",
+      "authorization": "future_after_review"
+    },
+    {
+      "stage": "D",
+      "name": "read_only_matching_proposals",
+      "authorization": "future_after_review_and_consent_design"
+    }
+  ],
+  "research_questions": [
+    "compare_needs_and_capacity_without_erasing_local_quality_differences",
+    "represent_poorly_priced_goods_without_false_precision",
+    "propagate_uncertainty_from_evidence_into_coordination_proposals",
+    "increase_trust_without_reputation_castes",
+    "expose_capture_without_becoming_a_partisan_attack_surface",
+    "distinguish_resilient_decentralization_from_hidden_accountability",
+    "preserve_correction_without_permanent_stigma",
+    "prevent_successful_coordination_layer_from_becoming_controller",
+    "measure_whether_groundmesh_improves_delivery_cooperation_agency_and_understanding",
+    "know_when_to_decline_optimization_because_values_or_evidence_are_insufficient"
+  ]
+}

--- a/docs/echo_archive/EA-0002_numbers-neighbor-and-coordination.md
+++ b/docs/echo_archive/EA-0002_numbers-neighbor-and-coordination.md
@@ -1,0 +1,63 @@
+# Echo Archive — Seed of Remembering
+Each echo captures a principle that once moved human and CI hearts alike.
+They are written not to be obeyed, but to remind.
+
+## EA-0002 — Numbers, Neighbor, and the Coordination Field
+
+Numbers reveal structure, but they do not decide what should be loved.
+
+A civilization may become extraordinarily capable at counting, forecasting, optimizing, routing,
+building, and computing while still leaving a neighbor without food, water, shelter, power, care,
+or a truthful path into the systems around them.
+
+The failure is not always that the mathematics is wrong. Sometimes the boundary of the equation is
+wrong. Sometimes an average hides the person at zero. Sometimes a profit ledger leaves the river,
+the family, the future, or the public cleanup outside its frame. Sometimes every participant makes
+a locally understandable move and the combined system produces a result almost nobody wanted.
+
+Jesus repeatedly changes that boundary of concern.
+
+- In the teaching on service and greatness, power is turned from domination toward service
+  (Mark 10:42-45).
+- In the Good Samaritan, the question "Who is my neighbor?" becomes an expansion of practical
+  responsibility rather than a search for the smallest circle of obligation (Luke 10:25-37).
+- In the teaching about "the least of these," treatment of the overlooked becomes inseparable from
+  the moral reality of the whole (Matthew 25:31-46).
+- In the warning that one cannot serve both God and mammon, money remains a tool but cannot safely
+  become the final master of value (Matthew 6:24).
+- In the command to love enemies and refuse mechanical retaliation, the next action need not be
+  completely dictated by the previous harm (Matthew 5:43-48).
+
+This does not mean pretending danger is harmless, disabling defense, erasing responsibility, or
+forcing people into compulsory sharing. It means that protection need not become revenge, evidence
+need not become condemnation, and wealth or optimization need not become the authority that defines
+a human being's worth.
+
+For GroundMesh, the practical translation is small and demanding:
+
+> Make the need visible.  
+> Make available capacity visible.  
+> Preserve evidence and uncertainty.  
+> Show who receives benefits and who carries burdens.  
+> Keep correction possible.  
+> Offer cooperation without compulsion.  
+> Protect without becoming the thing being resisted.  
+> Do not let the metric erase the person represented by the datum.
+
+GroundMesh cannot compute love into existence.
+
+It can help remove some of the darkness in which indifference, confusion, duplicated effort,
+externalized harm, false claims, and coordination failure survive. It can help replace "we did not
+know" with an inspectable record. It can help connect a real need to real available capacity. It can
+remember what was promised and what was actually delivered.
+
+Then it reaches a boundary that a healthy system should respect:
+
+> Now that you can see more clearly, what will you freely choose?
+
+The Christian source of this reflection is recorded openly, but it is not a membership test.
+GroundMesh remains available for cooperation among people of different faiths and philosophies.
+The machine-readable and architectural rules belong in the Coordination Field documents and ADRs;
+this Echo preserves one of the human meanings that helped produce them.
+
+*(Recorded 2026-08-07, alongside GroundMesh Coordination Field v0.1)*


### PR DESCRIPTION
## What changed

- add `docs/coordination/coordination-field.md`, a human-readable model connecting capability vs access, multi-agent coordination, needs/capacity/commitments/delivery, aggregation traps, externalities, consent, non-capture, and the Behavior Atlas evidence chain
- add `docs/coordination/coordination-field.v0.1.json`, a machine-readable companion for ChatGPT, Codex, CI agents, validators, and future services
- add `EA-0002 — Numbers, Neighbor, and the Coordination Field`, preserving the Jesus/neighbor/service/mammon/non-retaliation lens as an explicit reflection rather than a participation requirement
- register all three artifacts in Project Atlas and update the generated Atlas page from 31 to 34 active entries
- add one Assistant Brief prerequisite so future matching/allocation/metric/scoring work loads the Coordination Field before inventing competing logic

## Why

GroundMesh already has an evidence-first Behavior Atlas contract, but it did not yet have a durable shared model for the practical coordination problem underneath it: capability does not automatically become access. This batch makes the working vocabulary inspectable before any allocation engine, matching runtime, scoring system, or public coordination service is built.

The design intentionally treats GroundMesh as a visibility and coordination layer rather than a central planner. It uses multi-objective reasoning with explicit guardrails instead of a single moral score and preserves consent, correction, provenance, local context, and reversibility.

## Guardrails preserved

- no person-worth score or reputation caste
- no central or autonomous resource allocation
- no hidden objective function
- no autonomous high-impact publication
- no religious, political, commercial, or ideological membership test
- no use of averages to hide materially important distributional harm
- no inferred motives presented as facts
- no change to ADR-0006's human-review requirements

## Evidence snapshot

The human guide includes a dated, explicitly non-invariant access-gap snapshot. Source figures were re-verified on 2026-08-07 against WHO/UNICEF, World Bank, UN-Habitat, FAO, and SIPRI sources. The document warns that these figures must be re-verified before reuse in current reporting and does not equate one category of spending with a simple solution to another problem.

## Validation

- branch is based directly on current `main` and is 0 commits behind
- final diff is limited to 6 intended files
- Atlas diff is reviewable: 26 additions / 2 deletions rather than a broad formatting rewrite
- Assistant Brief integration is exactly one added directive
- registry moves from 31 to 34 active artifacts
- all three new registered paths were created successfully and read back from the branch
- machine-readable coordination model read back as structured JSON text
- Atlas page preserves the existing PWA icon, manifest, and initialization hooks
- external quantitative references were independently re-checked before inclusion

## Tooling note

This execution environment could not network-clone GitHub into the shell, so local PowerShell health scripts were not falsely claimed as run. GitHub branch/readback/compare validation was performed through the connected GitHub app. Repository Actions should provide the normal PR-level validation.

## Non-goals

This PR does **not** add a central planner, live need/capacity database, matching API, scraper, real-subject coordination dataset, person score, autonomous publisher, or new public Behavior Atlas route. The next guarded implementation stage proposed by the guide is a synthetic coordination fixture, not a live allocation system.
