### PR TITLE
coordination: add synthetic Stage-B breathing test

### DIFF
--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -45,6 +45,11 @@ jobs:
         run: |
           ./scripts/behavior-atlas-validate.ps1 -RequireSynthetic
 
+      - name: Validate Coordination Field synthetic breathing test
+        shell: pwsh
+        run: |
+          ./scripts/coordination-fixture-validate.ps1
+
       - name: Check links with lychee
         uses: lycheeverse/lychee-action@v1
         with:

--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -178,11 +178,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>34</strong>
+          <strong>35</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>34</strong>
+          <strong>35</strong>
         </div>
       </div>
     </section>
@@ -479,6 +479,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/templates/Registration_Pilot_Scope_Canvas.md</code></td>
   <td>Compact fill-in canvas for defining the first real registration pilot before opening intake beyond simple public contact.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../coordination/synthetic-breathing-test.md">TEST-COORDINATION-SYNTHETIC-V0-1</a></td>
+  <td><strong>Coordination Field Synthetic Breathing Test v0.1</strong></td>
+  <td><span class="chip">test</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/coordination/synthetic-breathing-test.md</code></td>
+  <td>Guarded Stage-B fictional need-to-capacity cycle paired with a JSON fixture and repo-health validator; tests consent-sensitive commitments and delivery without real subjects or allocation authority.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../protocols/TP-03.md">TP-03</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -277,6 +277,14 @@
       "status": "active",
       "path": "docs/echo_archive/EA-0002_numbers-neighbor-and-coordination.md",
       "summary": "Reflection connecting numbers, hidden accounting boundaries, Jesus' teachings on neighbor, service, mammon, and non-retaliation, and GroundMesh's voluntary coordination posture."
+    },
+    {
+      "id": "TEST-COORDINATION-SYNTHETIC-V0-1",
+      "name": "Coordination Field Synthetic Breathing Test v0.1",
+      "type": "test",
+      "status": "active",
+      "path": "docs/coordination/synthetic-breathing-test.md",
+      "summary": "Guarded Stage-B fictional need-to-capacity cycle paired with a JSON fixture and repo-health validator; tests consent-sensitive commitments and delivery without real subjects or allocation authority."
     }
   ]
 }

--- a/docs/coordination/examples/synthetic-need-capacity-cycle.v0.1.json
+++ b/docs/coordination/examples/synthetic-need-capacity-cycle.v0.1.json
@@ -1,0 +1,171 @@
+{
+  "fixture_id": "GM-COORDINATION-SYNTHETIC-CYCLE-V0-1",
+  "version": "0.1",
+  "status": "synthetic_internal_test",
+  "date": "2026-08-07",
+  "is_synthetic": true,
+  "public_release": false,
+  "purpose": "Exercise Coordination Field arithmetic and consent-sensitive state transitions without real subjects or real allocation.",
+  "related": [
+    "docs/coordination/coordination-field.md",
+    "docs/coordination/coordination-field.v0.1.json",
+    "docs/coordination/synthetic-breathing-test.md"
+  ],
+  "provenance": {
+    "kind": "synthetic_test_fixture",
+    "real_world_claims": false,
+    "source": "constructed-for-groundmesh-stage-b",
+    "uncertainty": "none-about-arithmetic; scenario itself is fictional"
+  },
+  "resource": {
+    "resource_id": "synthetic-potable-water-delivery",
+    "class": "potable_water_delivery",
+    "unit": "m3/day",
+    "quality_threshold": "GM-SYNTH-WQ-1",
+    "time_window": {
+      "start": "2026-08-07T00:00:00Z",
+      "end": "2026-08-08T00:00:00Z"
+    },
+    "geography": "fictional-only",
+    "scope": "one fictional locality and one fictional provider"
+  },
+  "participants": [
+    {
+      "participant_id": "fictional-blue-harbor-locality",
+      "name": "Blue Harbor Locality",
+      "participant_type": "locality",
+      "fictional": true,
+      "is_person": false
+    },
+    {
+      "participant_id": "fictional-green-ridge-water-cooperative",
+      "name": "Green Ridge Water Cooperative",
+      "participant_type": "provider",
+      "fictional": true,
+      "is_person": false
+    }
+  ],
+  "semantics": {
+    "N": "assessed need for the defined resource and window",
+    "D": "verified delivery already completed in the defined window",
+    "K_outstanding": "valid committed quantity not yet delivered, cancelled, expired, or removed",
+    "C_remaining": "undelivered capacity still available in the defined window, including outstanding committed and uncommitted spare capacity",
+    "U_formula": "max(0, N - D)",
+    "G_formula": "max(0, N - D - K_outstanding)",
+    "S_formula": "max(0, C_remaining - K_outstanding)"
+  },
+  "authority": {
+    "proposal_only": true,
+    "allocation_authority": false,
+    "autonomous_commitment": false,
+    "consent_required": true
+  },
+  "states": [
+    {
+      "state_id": "S0-observed",
+      "stage": "observed",
+      "need": {
+        "N": 100,
+        "D": 20,
+        "K_outstanding": 30,
+        "U": 80,
+        "G": 50
+      },
+      "capacity": {
+        "C_remaining": 75,
+        "K_outstanding": 20,
+        "S": 55
+      },
+      "proposal": null,
+      "transition_from_previous": null
+    },
+    {
+      "state_id": "S1-proposed",
+      "stage": "proposed",
+      "need": {
+        "N": 100,
+        "D": 20,
+        "K_outstanding": 30,
+        "U": 80,
+        "G": 50
+      },
+      "capacity": {
+        "C_remaining": 75,
+        "K_outstanding": 20,
+        "S": 55
+      },
+      "proposal": {
+        "proposal_id": "synthetic-match-001",
+        "amount": 40,
+        "consent_state": "pending",
+        "binding": false
+      },
+      "transition_from_previous": {
+        "kind": "surface_candidate_match",
+        "quantity_effect": 0
+      }
+    },
+    {
+      "state_id": "S2-committed",
+      "stage": "committed",
+      "need": {
+        "N": 100,
+        "D": 20,
+        "K_outstanding": 70,
+        "U": 80,
+        "G": 10
+      },
+      "capacity": {
+        "C_remaining": 75,
+        "K_outstanding": 60,
+        "S": 15
+      },
+      "proposal": {
+        "proposal_id": "synthetic-match-001",
+        "amount": 40,
+        "consent_state": "accepted",
+        "binding": true
+      },
+      "transition_from_previous": {
+        "kind": "record_explicit_consent_and_commitment",
+        "committed_amount": 40,
+        "delivery_effect": 0
+      }
+    },
+    {
+      "state_id": "S3-partial-delivery",
+      "stage": "partial_verified_delivery",
+      "need": {
+        "N": 100,
+        "D": 55,
+        "K_outstanding": 35,
+        "U": 45,
+        "G": 10
+      },
+      "capacity": {
+        "C_remaining": 40,
+        "K_outstanding": 25,
+        "S": 15
+      },
+      "proposal": {
+        "proposal_id": "synthetic-match-001",
+        "amount": 40,
+        "consent_state": "accepted",
+        "binding": true
+      },
+      "transition_from_previous": {
+        "kind": "verify_partial_delivery",
+        "delivered_amount": 35,
+        "remaining_match_commitment": 5
+      }
+    }
+  ],
+  "expected_invariants": [
+    "pending proposal changes no K, D, or C quantities",
+    "accepted proposal increases outstanding commitment on compatible need and capacity ledgers by the same amount",
+    "verified delivery increases D and decreases need-side K_outstanding by the delivered amount",
+    "verified delivery decreases capacity-side C_remaining and K_outstanding by the delivered amount",
+    "delivery of an already-planned amount lowers U but does not by itself change G or S",
+    "no state contains person scoring, ranking, inferred motive, or autonomous allocation authority"
+  ]
+}

--- a/docs/coordination/synthetic-breathing-test.md
+++ b/docs/coordination/synthetic-breathing-test.md
@@ -1,0 +1,192 @@
+# GroundMesh Coordination Field — Synthetic Breathing Test v0.1
+
+Status: Guarded Stage-B test  
+Date: 2026-08-07  
+Scope: Fictional need ↔ capacity state transition only  
+Related: `docs/coordination/coordination-field.md`, `docs/coordination/coordination-field.v0.1.json`
+
+## Why this test exists
+
+The Coordination Field defines a vocabulary for need, capacity, commitments, delivery, unmet need, planned gap, and spare capacity. Before any real-world dataset or matching service uses those quantities, GroundMesh needs one small example that can be calculated repeatedly and rejected automatically when the state becomes inconsistent.
+
+This test is intentionally fictional. It does not represent a real locality, organization, person, water system, contract, need, or offer. It authorizes no allocation and creates no public matching service.
+
+Its purpose is to answer a narrower engineering question:
+
+> Do the coordination quantities remain coherent as a possible match moves from observation → proposal → consented commitment → partial verified delivery?
+
+## Clarification discovered by the test
+
+Walking the v0.1 equations through delivery exposes an ambiguity that is easy to miss in prose.
+
+The planned-gap expression is:
+
+```text
+G = max(0, N - D - K_valid)
+```
+
+If `K_valid` includes quantities that have already been delivered, delivery is counted once in `D` and again inside `K`, which is wrong.
+
+For Stage B, GroundMesh therefore uses the following operational interpretation:
+
+- `K_outstanding` = valid commitment that is still outstanding and has **not yet been delivered, cancelled, expired, or otherwise removed**;
+- `C_remaining` = capacity still physically or operationally available within the defined time window at the current snapshot, including both outstanding committed capacity and uncommitted spare capacity;
+- a pending proposal is **not** a commitment;
+- consent may convert a proposal into an outstanding commitment;
+- verified delivery transfers quantity out of outstanding commitment and into verified delivery;
+- on the supply side, verified delivery also consumes the corresponding remaining capacity.
+
+The Stage-B calculations are therefore:
+
+```text
+U = max(0, N - D)
+G = max(0, N - D - K_outstanding)
+S = max(0, C_remaining - K_outstanding)
+```
+
+This is a test clarification, not a claim that the v0.1 vocabulary is final. A later Coordination Field revision should make the snapshot semantics explicit in the core model.
+
+## Fictional scenario
+
+Two invented participants are used:
+
+- **Blue Harbor Locality** — a fictional locality with an assessed potable-water delivery need;
+- **Green Ridge Water Cooperative** — a fictional provider with compatible spare delivery capacity.
+
+The resource is fictional potable-water delivery measured in `m3/day` under an invented quality threshold `GM-SYNTH-WQ-1` for one fictional daily window.
+
+No geographic coordinates, real names, real URLs, personal records, or real operational claims are included.
+
+## State 0 — observed
+
+Need side:
+
+```text
+N = 100
+D = 20
+K_outstanding = 30
+U = 80
+G = 50
+```
+
+Capacity side:
+
+```text
+C_remaining = 75
+K_outstanding = 20
+S = 55
+```
+
+Interpretation: 50 units of need remain unplanned after existing commitments, while the provider has 55 units of spare compatible capacity.
+
+## State 1 — proposal only
+
+GroundMesh surfaces a possible match of `40` units.
+
+The proposal is pending and non-binding.
+
+Therefore **nothing in the accounting changes yet**:
+
+```text
+need:     N=100, D=20, K=30, U=80, G=50
+capacity: C=75, K=20, S=55
+proposal: 40, consent=pending, binding=false
+```
+
+This is important. A recommendation, alert, or CI suggestion must not silently become a commitment.
+
+## State 2 — consented commitment
+
+Both fictional participants accept the 40-unit proposal.
+
+The amount becomes an outstanding commitment on both compatible ledgers:
+
+```text
+need:     N=100, D=20, K=70, U=80, G=10
+capacity: C=75, K=60, S=15
+proposal: 40, consent=accepted, binding=true
+```
+
+The planned gap falls from 50 to 10. Spare capacity falls from 55 to 15.
+
+No delivery has happened yet, so `D` and `C_remaining` do not change at this transition.
+
+## State 3 — partial verified delivery
+
+The fictional provider delivers and verifies `35` of the 40 newly committed units.
+
+Delivery moves 35 units from outstanding commitment into verified delivery on the need side, and consumes 35 units of remaining supply-side capacity:
+
+```text
+need:     N=100, D=55, K=35, U=45, G=10
+capacity: C=40, K=25, S=15
+```
+
+Notice two useful invariants:
+
+- `U` falls because real delivery occurred;
+- `G` and `S` remain unchanged for the delivered portion because delivery replaces an already-counted outstanding commitment rather than creating new planning coverage.
+
+This is the exact place where an incorrectly defined `K` would double-count.
+
+## What the validator checks
+
+`scripts/coordination-fixture-validate.ps1` checks that:
+
+1. the fixture is explicitly synthetic and non-public;
+2. all participants are fictional and no person subject is present;
+3. units, quality threshold, time window, provenance, and uncertainty are declared;
+4. state IDs are unique and the expected four-stage sequence exists;
+5. `U`, `G`, and `S` equal the formulas above in every state;
+6. all quantities are non-negative and commitments do not exceed the compatible need/capacity boundary in this fixture;
+7. the pending proposal changes no commitment or delivery quantity;
+8. the proposed amount fits both the observed planned gap and observed spare capacity;
+9. consent moves the proposed amount into outstanding commitment on both sides without inventing delivery;
+10. partial delivery increases `D`, decreases outstanding `K`, and consumes `C_remaining` by the same delivered amount;
+11. forbidden scoring/ranking/person-worth fields do not appear;
+12. the fixture grants GroundMesh no allocation authority.
+
+The validator is wired into `repo-health` so later edits cannot silently break the example.
+
+## What this test does not prove
+
+Passing this fixture does **not** prove that GroundMesh can safely coordinate real water, food, housing, energy, money, medicine, logistics, or emergency resources.
+
+It does not test:
+
+- identity or authorization;
+- legal commitments;
+- real quality standards;
+- transport feasibility;
+- price or affordability;
+- conflicting claims;
+- privacy;
+- adversarial data;
+- multi-provider matching;
+- partial consent among many parties;
+- expiry, cancellation, substitution, or correction races;
+- scarce-resource fairness;
+- emergency prioritization;
+- real-world governance.
+
+Those belong to later guarded work.
+
+## Success criterion
+
+Stage B succeeds when the repository can repeatedly demonstrate:
+
+```text
+observation
+-> non-binding proposal
+-> explicit consent
+-> outstanding commitment
+-> verified partial delivery
+```
+
+while keeping the arithmetic coherent and preserving the rule:
+
+> GroundMesh may surface and verify a possible cooperation path; it does not convert a proposal into action without consent.
+
+## Next gate
+
+Only after this fixture remains understandable and stable should GroundMesh consider Stage C: one low-risk, harmless, public-data demonstration with no person ranking and no autonomous decision.

--- a/scripts/coordination-fixture-validate.ps1
+++ b/scripts/coordination-fixture-validate.ps1
@@ -1,0 +1,325 @@
+param(
+  [string]$ModelPath = "docs/coordination/coordination-field.v0.1.json",
+  [string]$FixturePath = "docs/coordination/examples/synthetic-need-capacity-cycle.v0.1.json"
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$script:ValidationErrors = @()
+
+function Resolve-RepoPath {
+  param([string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
+  return Join-Path $RepoRoot $Path
+}
+
+function Add-ValidationError {
+  param([string]$Message)
+  $script:ValidationErrors += $Message
+}
+
+function Get-PropertyValue {
+  param(
+    [object]$Object,
+    [string]$Name
+  )
+  if ($null -eq $Object) { return $null }
+  $property = $Object.PSObject.Properties[$Name]
+  if ($null -eq $property) { return $null }
+  return $property.Value
+}
+
+function Test-ForbiddenProperties {
+  param(
+    [object]$Node,
+    [string]$Path = '$'
+  )
+
+  if ($null -eq $Node -or $Node -is [string] -or $Node.GetType().IsValueType) { return }
+
+  if ($Node -is [System.Collections.IEnumerable] -and
+      $Node -isnot [System.Collections.IDictionary] -and
+      $Node -isnot [System.Management.Automation.PSCustomObject]) {
+    $index = 0
+    foreach ($item in $Node) {
+      Test-ForbiddenProperties -Node $item -Path ("{0}[{1}]" -f $Path, $index)
+      $index++
+    }
+    return
+  }
+
+  $forbidden = @(
+    'score',
+    'rank',
+    'ranking',
+    'person_score',
+    'reputation_score',
+    'moral_label',
+    'guilt_finding',
+    'inferred_motive',
+    'composite_score',
+    'automatic_allocation',
+    'allocation_order'
+  )
+
+  foreach ($property in $Node.PSObject.Properties) {
+    $name = $property.Name.ToLowerInvariant()
+    if ($forbidden -contains $name) {
+      Add-ValidationError ("Forbidden field at {0}.{1}" -f $Path, $property.Name)
+    }
+    Test-ForbiddenProperties -Node $property.Value -Path ("{0}.{1}" -f $Path, $property.Name)
+  }
+}
+
+function Assert-NumberEqual {
+  param(
+    [double]$Actual,
+    [double]$Expected,
+    [string]$Context
+  )
+  if ([Math]::Abs($Actual - $Expected) -gt 0.0000001) {
+    Add-ValidationError ("{0}: expected {1}, got {2}." -f $Context, $Expected, $Actual)
+  }
+}
+
+function Assert-StringEqual {
+  param(
+    [string]$Actual,
+    [string]$Expected,
+    [string]$Context
+  )
+  if ($Actual -ne $Expected) {
+    Add-ValidationError ("{0}: expected '{1}', got '{2}'." -f $Context, $Expected, $Actual)
+  }
+}
+
+function Test-NeedState {
+  param([object]$State)
+
+  $n = [double]$State.need.N
+  $d = [double]$State.need.D
+  $k = [double]$State.need.K_outstanding
+  $u = [double]$State.need.U
+  $g = [double]$State.need.G
+
+  foreach ($pair in @(
+    @('N', $n),
+    @('D', $d),
+    @('K_outstanding', $k),
+    @('U', $u),
+    @('G', $g)
+  )) {
+    if ([double]$pair[1] -lt 0) {
+      Add-ValidationError ("State '{0}' need.{1} must be non-negative." -f $State.state_id, $pair[0])
+    }
+  }
+
+  if ($d -gt $n) {
+    Add-ValidationError ("State '{0}' delivery exceeds assessed need." -f $State.state_id)
+  }
+  if ($k -gt [Math]::Max(0, $n - $d)) {
+    Add-ValidationError ("State '{0}' outstanding need-side commitments exceed the remaining need boundary." -f $State.state_id)
+  }
+
+  Assert-NumberEqual -Actual $u -Expected ([Math]::Max(0, $n - $d)) -Context ("{0}.need.U" -f $State.state_id)
+  Assert-NumberEqual -Actual $g -Expected ([Math]::Max(0, $n - $d - $k)) -Context ("{0}.need.G" -f $State.state_id)
+}
+
+function Test-CapacityState {
+  param([object]$State)
+
+  $c = [double]$State.capacity.C_remaining
+  $k = [double]$State.capacity.K_outstanding
+  $s = [double]$State.capacity.S
+
+  foreach ($pair in @(
+    @('C_remaining', $c),
+    @('K_outstanding', $k),
+    @('S', $s)
+  )) {
+    if ([double]$pair[1] -lt 0) {
+      Add-ValidationError ("State '{0}' capacity.{1} must be non-negative." -f $State.state_id, $pair[0])
+    }
+  }
+
+  if ($k -gt $c) {
+    Add-ValidationError ("State '{0}' outstanding capacity commitments exceed remaining capacity." -f $State.state_id)
+  }
+
+  Assert-NumberEqual -Actual $s -Expected ([Math]::Max(0, $c - $k)) -Context ("{0}.capacity.S" -f $State.state_id)
+}
+
+function Get-StateById {
+  param(
+    [object[]]$States,
+    [string]$Id
+  )
+  $matches = @($States | Where-Object { [string]$_.state_id -eq $Id })
+  if ($matches.Count -ne 1) {
+    Add-ValidationError ("Expected exactly one state '{0}', found {1}." -f $Id, $matches.Count)
+    return $null
+  }
+  return $matches[0]
+}
+
+$modelAbs = Resolve-RepoPath -Path $ModelPath
+$fixtureAbs = Resolve-RepoPath -Path $FixturePath
+
+if (-not (Test-Path $modelAbs)) { throw "Coordination model not found: $modelAbs" }
+if (-not (Test-Path $fixtureAbs)) { throw "Coordination fixture not found: $fixtureAbs" }
+
+try {
+  $model = Get-Content $modelAbs -Raw | ConvertFrom-Json
+} catch {
+  throw "Coordination model JSON is invalid: $($_.Exception.Message)"
+}
+
+try {
+  $fixture = Get-Content $fixtureAbs -Raw | ConvertFrom-Json
+} catch {
+  throw "Coordination fixture JSON is invalid: $($_.Exception.Message)"
+}
+
+Assert-StringEqual -Actual ([string]$model.version) -Expected '0.1' -Context 'model.version'
+Assert-StringEqual -Actual ([string]$model.quantities.U.formula) -Expected 'max(0, N - D)' -Context 'model.quantities.U.formula'
+Assert-StringEqual -Actual ([string]$model.quantities.G.formula) -Expected 'max(0, N - D - K_valid)' -Context 'model.quantities.G.formula'
+Assert-StringEqual -Actual ([string]$model.quantities.S.formula) -Expected 'max(0, C - K)' -Context 'model.quantities.S.formula'
+
+Assert-StringEqual -Actual ([string]$fixture.version) -Expected '0.1' -Context 'fixture.version'
+if (-not [bool]$fixture.is_synthetic) { Add-ValidationError 'Fixture must set is_synthetic = true.' }
+if ([bool]$fixture.public_release) { Add-ValidationError 'Synthetic fixture must set public_release = false.' }
+
+Test-ForbiddenProperties -Node $fixture
+
+if (-not [bool]$fixture.authority.proposal_only) { Add-ValidationError 'Fixture must remain proposal-only.' }
+if ([bool]$fixture.authority.allocation_authority) { Add-ValidationError 'Fixture must not grant allocation authority.' }
+if ([bool]$fixture.authority.autonomous_commitment) { Add-ValidationError 'Fixture must not permit autonomous commitment.' }
+if (-not [bool]$fixture.authority.consent_required) { Add-ValidationError 'Fixture must require consent.' }
+
+$participants = @($fixture.participants)
+if ($participants.Count -lt 2) { Add-ValidationError 'Fixture requires at least two fictional participants.' }
+$participantIds = @{}
+foreach ($participant in $participants) {
+  $id = [string]$participant.participant_id
+  if ([string]::IsNullOrWhiteSpace($id)) {
+    Add-ValidationError 'Participant is missing participant_id.'
+  } elseif ($participantIds.ContainsKey($id)) {
+    Add-ValidationError ("Duplicate participant_id '{0}'." -f $id)
+  } else {
+    $participantIds[$id] = $true
+  }
+
+  if (-not [bool]$participant.fictional) {
+    Add-ValidationError ("Participant '{0}' must be explicitly fictional." -f $id)
+  }
+  if ([bool]$participant.is_person -or [string]$participant.participant_type -eq 'person') {
+    Add-ValidationError ("Participant '{0}' may not be a person in this synthetic fixture." -f $id)
+  }
+}
+
+foreach ($required in @('resource_id', 'class', 'unit', 'quality_threshold', 'geography', 'scope')) {
+  $value = Get-PropertyValue -Object $fixture.resource -Name $required
+  if ([string]::IsNullOrWhiteSpace([string]$value)) {
+    Add-ValidationError ("resource.{0} is required." -f $required)
+  }
+}
+
+$start = [DateTimeOffset]::MinValue
+$end = [DateTimeOffset]::MinValue
+if (-not [DateTimeOffset]::TryParse([string]$fixture.resource.time_window.start, [ref]$start)) {
+  Add-ValidationError 'resource.time_window.start is not a valid date-time.'
+}
+if (-not [DateTimeOffset]::TryParse([string]$fixture.resource.time_window.end, [ref]$end)) {
+  Add-ValidationError 'resource.time_window.end is not a valid date-time.'
+}
+if ($end -le $start) { Add-ValidationError 'resource.time_window.end must be after start.' }
+
+foreach ($semantic in @('N', 'D', 'K_outstanding', 'C_remaining', 'U_formula', 'G_formula', 'S_formula')) {
+  $value = Get-PropertyValue -Object $fixture.semantics -Name $semantic
+  if ([string]::IsNullOrWhiteSpace([string]$value)) {
+    Add-ValidationError ("semantics.{0} is required." -f $semantic)
+  }
+}
+
+$states = @($fixture.states)
+if ($states.Count -ne 4) { Add-ValidationError ("Expected four test states, found {0}." -f $states.Count) }
+
+$stateIds = @{}
+foreach ($state in $states) {
+  $id = [string]$state.state_id
+  if ([string]::IsNullOrWhiteSpace($id)) {
+    Add-ValidationError 'State is missing state_id.'
+  } elseif ($stateIds.ContainsKey($id)) {
+    Add-ValidationError ("Duplicate state_id '{0}'." -f $id)
+  } else {
+    $stateIds[$id] = $true
+  }
+  Test-NeedState -State $state
+  Test-CapacityState -State $state
+}
+
+$s0 = Get-StateById -States $states -Id 'S0-observed'
+$s1 = Get-StateById -States $states -Id 'S1-proposed'
+$s2 = Get-StateById -States $states -Id 'S2-committed'
+$s3 = Get-StateById -States $states -Id 'S3-partial-delivery'
+
+if ($null -ne $s0 -and $null -ne $s1 -and $null -ne $s2 -and $null -ne $s3) {
+  Assert-StringEqual -Actual ([string]$s0.stage) -Expected 'observed' -Context 'S0.stage'
+  Assert-StringEqual -Actual ([string]$s1.stage) -Expected 'proposed' -Context 'S1.stage'
+  Assert-StringEqual -Actual ([string]$s2.stage) -Expected 'committed' -Context 'S2.stage'
+  Assert-StringEqual -Actual ([string]$s3.stage) -Expected 'partial_verified_delivery' -Context 'S3.stage'
+
+  foreach ($name in @('N', 'D', 'K_outstanding', 'U', 'G')) {
+    Assert-NumberEqual -Actual ([double](Get-PropertyValue -Object $s1.need -Name $name)) -Expected ([double](Get-PropertyValue -Object $s0.need -Name $name)) -Context ("pending proposal preserves need.{0}" -f $name)
+  }
+  foreach ($name in @('C_remaining', 'K_outstanding', 'S')) {
+    Assert-NumberEqual -Actual ([double](Get-PropertyValue -Object $s1.capacity -Name $name)) -Expected ([double](Get-PropertyValue -Object $s0.capacity -Name $name)) -Context ("pending proposal preserves capacity.{0}" -f $name)
+  }
+
+  if ($null -eq $s1.proposal) {
+    Add-ValidationError 'S1 must contain a proposal.'
+  } else {
+    $amount = [double]$s1.proposal.amount
+    if ($amount -le 0) { Add-ValidationError 'S1 proposal amount must be positive.' }
+    if ($amount -gt [double]$s0.need.G) { Add-ValidationError 'S1 proposal exceeds observed planned gap.' }
+    if ($amount -gt [double]$s0.capacity.S) { Add-ValidationError 'S1 proposal exceeds observed spare capacity.' }
+    Assert-StringEqual -Actual ([string]$s1.proposal.consent_state) -Expected 'pending' -Context 'S1.proposal.consent_state'
+    if ([bool]$s1.proposal.binding) { Add-ValidationError 'Pending S1 proposal must not be binding.' }
+
+    Assert-StringEqual -Actual ([string]$s2.proposal.consent_state) -Expected 'accepted' -Context 'S2.proposal.consent_state'
+    if (-not [bool]$s2.proposal.binding) { Add-ValidationError 'Accepted S2 proposal must be binding in the synthetic state model.' }
+    Assert-NumberEqual -Actual ([double]$s2.proposal.amount) -Expected $amount -Context 'S2.proposal.amount'
+
+    Assert-NumberEqual -Actual ([double]$s2.need.N) -Expected ([double]$s1.need.N) -Context 'consent preserves need.N'
+    Assert-NumberEqual -Actual ([double]$s2.need.D) -Expected ([double]$s1.need.D) -Context 'consent does not invent delivery'
+    Assert-NumberEqual -Actual ([double]$s2.need.K_outstanding) -Expected ([double]$s1.need.K_outstanding + $amount) -Context 'consent adds need-side outstanding commitment'
+    Assert-NumberEqual -Actual ([double]$s2.capacity.C_remaining) -Expected ([double]$s1.capacity.C_remaining) -Context 'consent does not consume capacity before delivery'
+    Assert-NumberEqual -Actual ([double]$s2.capacity.K_outstanding) -Expected ([double]$s1.capacity.K_outstanding + $amount) -Context 'consent adds capacity-side outstanding commitment'
+
+    $delivered = [double]$s3.transition_from_previous.delivered_amount
+    if ($delivered -le 0) { Add-ValidationError 'S3 delivered_amount must be positive.' }
+    if ($delivered -gt $amount) { Add-ValidationError 'S3 delivered_amount exceeds accepted proposal amount.' }
+
+    Assert-NumberEqual -Actual ([double]$s3.need.N) -Expected ([double]$s2.need.N) -Context 'delivery preserves need.N'
+    Assert-NumberEqual -Actual ([double]$s3.need.D) -Expected ([double]$s2.need.D + $delivered) -Context 'delivery increases need.D'
+    Assert-NumberEqual -Actual ([double]$s3.need.K_outstanding) -Expected ([double]$s2.need.K_outstanding - $delivered) -Context 'delivery reduces need-side outstanding commitment'
+    Assert-NumberEqual -Actual ([double]$s3.capacity.C_remaining) -Expected ([double]$s2.capacity.C_remaining - $delivered) -Context 'delivery consumes remaining capacity'
+    Assert-NumberEqual -Actual ([double]$s3.capacity.K_outstanding) -Expected ([double]$s2.capacity.K_outstanding - $delivered) -Context 'delivery reduces capacity-side outstanding commitment'
+    Assert-NumberEqual -Actual ([double]$s3.need.U) -Expected ([double]$s2.need.U - $delivered) -Context 'delivery reduces observed unmet need'
+    Assert-NumberEqual -Actual ([double]$s3.need.G) -Expected ([double]$s2.need.G) -Context 'delivery of planned quantity preserves planned gap'
+    Assert-NumberEqual -Actual ([double]$s3.capacity.S) -Expected ([double]$s2.capacity.S) -Context 'delivery of committed quantity preserves spare capacity'
+    Assert-NumberEqual -Actual ([double]$s3.transition_from_previous.remaining_match_commitment) -Expected ($amount - $delivered) -Context 'remaining match commitment'
+  }
+}
+
+if ($script:ValidationErrors.Count -gt 0) {
+  Write-Host 'Coordination fixture validation failed:'
+  foreach ($errorMessage in $script:ValidationErrors) {
+    Write-Host ("- {0}" -f $errorMessage)
+  }
+  throw ("Coordination fixture validation failed with {0} error(s)." -f $script:ValidationErrors.Count)
+}
+
+Write-Host ("Coordination synthetic breathing test OK: {0} states validated." -f $states.Count)


### PR DESCRIPTION
## What changed

- add `docs/coordination/synthetic-breathing-test.md`, a human-readable Stage-B walkthrough of observation → proposal → consented commitment → partial verified delivery
- add `docs/coordination/examples/synthetic-need-capacity-cycle.v0.1.json`, a fully fictional need/capacity state cycle with no real subject data
- add `scripts/coordination-fixture-validate.ps1` to verify formulas, consent boundaries, transitions, non-negative quantities, fictional participants, and non-allocation guardrails
- run the new validator from `repo-health`
- register the breathing test in Project Atlas and regenerate Atlas from 34 to 35 active entries

## Why

The Coordination Field equations were useful but had not yet been forced through a concrete state transition. Walking the model through delivery exposed an important ambiguity: `G = N - D - K_valid` can double-count delivered quantity unless `K_valid` is operationally interpreted as the outstanding, not-yet-delivered portion of a valid commitment.

This guarded Stage-B test makes that behavior explicit without changing GroundMesh into a matching service. In the synthetic fixture:

- pending proposals do not alter commitments
- explicit consent moves a proposed amount into outstanding commitment
- verified delivery moves quantity out of outstanding commitment and into verified delivery
- supply-side remaining capacity decreases by the delivered amount
- delivering an already-planned quantity reduces observed unmet need while preserving planned gap and spare capacity for that portion

## Guardrails preserved

- entirely fictional participants, resource, quality threshold, and scenario
- no person subjects or person scoring
- no real need, offer, contract, geography, or operational claim
- no allocation authority
- no autonomous commitment
- consent required before a proposal becomes binding in the synthetic state model
- no public release
- no live matching API, service, watcher, or resource movement

## Expected arithmetic

Observed:
- need: `N=100, D=20, K=30, U=80, G=50`
- capacity: `C=75, K=20, S=55`

Pending 40-unit proposal:
- accounting remains unchanged

After consent:
- need: `K=70, G=10`
- capacity: `K=60, S=15`

After 35 units of verified partial delivery:
- need: `D=55, K=35, U=45, G=10`
- capacity: `C=40, K=25, S=15`

## Validation

Before opening this PR:

- branch is based directly on merged `main` and is 0 commits behind
- diff is limited to 6 intended files
- Atlas changes only the counters plus the new registered test row
- JSON fixture and validator were read back through the connected GitHub app
- local network cloning is unavailable in this environment, so PowerShell execution is delegated honestly to GitHub Actions rather than claimed as local validation

Repository CI should now exercise the new validator directly.

## Non-goals

This PR does not prove real-world coordination safety. It does not test identity, authorization, law, pricing, transport, privacy, adversarial data, multi-provider matching, scarce-resource fairness, emergency prioritization, or real governance. Those remain later guarded gates.
