### PR TITLE
feat(world): add lightweight public World surface

### DIFF
--- a/docs/atlas/index.html
+++ b/docs/atlas/index.html
@@ -178,11 +178,11 @@
       <div class="stats">
         <div class="stat">
           <span class="label">Entries</span>
-          <strong>35</strong>
+          <strong>36</strong>
         </div>
         <div class="stat">
           <span class="label">Active</span>
-          <strong>35</strong>
+          <strong>36</strong>
         </div>
       </div>
     </section>
@@ -447,6 +447,14 @@
   <td><span class="status status-active">active</span></td>
   <td><code>docs/register-pilot.html</code></td>
   <td>Minimal steward-run pilot form for self-registration and a few invited friends when the local intake host is active.</td>
+</tr>
+            <tr>
+  <td><a class="id-link" href="../world.html">PAGE-WORLD</a></td>
+  <td><strong>GroundMesh World</strong></td>
+  <td><span class="chip">page</span></td>
+  <td><span class="status status-active">active</span></td>
+  <td><code>docs/world.html</code></td>
+  <td>Lightweight public world view joining dated evidence-backed global needs with current GroundMesh participation paths and the consent-first coordination loop.</td>
 </tr>
             <tr>
   <td><a class="id-link" href="../behavior-atlas/schema/v0.1.schema.json">SCHEMA-BEHAVIOR-ATLAS-V0-1</a></td>

--- a/docs/atlas/registry.json
+++ b/docs/atlas/registry.json
@@ -220,6 +220,14 @@
       "summary": "Public-facing orientation page for the project landscape and navigation."
     },
     {
+      "id": "PAGE-WORLD",
+      "name": "GroundMesh World",
+      "type": "page",
+      "status": "active",
+      "path": "docs/world.html",
+      "summary": "Lightweight public world view joining dated evidence-backed global needs with current GroundMesh participation paths and the consent-first coordination loop."
+    },
+    {
       "id": "STATUS-PUBLIC",
       "name": "Public Status Snapshot",
       "type": "data",

--- a/docs/data/status.json
+++ b/docs/data/status.json
@@ -1,29 +1,33 @@
 {
-  "updated_utc": "2026-04-20T11:15:00Z",
+  "updated_utc": "2026-08-07T14:20:00Z",
   "components": {
     "deployment_source": {
       "status": "green",
-      "note": "GitHub Pages is now serving the docs-based site successfully through the GitHub Actions deployment path"
+      "note": "GitHub Pages serves the docs-based site through the GitHub Actions deployment path"
     },
     "home_page": {
       "status": "green",
-      "note": "Unified docs front door is live at the public root URL"
+      "note": "Canonical public front door is available at the repository Pages root and now points people toward the World view first"
+    },
+    "world_page": {
+      "status": "green",
+      "note": "Lightweight World page exposes dated global indicators, current participation paths, coordination boundaries, and evidence links without requiring an account"
     },
     "pwa_shell": {
       "status": "green",
-      "note": "Manifest, service worker, install helper banner, shared install wiring, and shared back-home app navigation are now present on the public docs entry pages"
+      "note": "Manifest, service worker, install helper banner, shared install wiring, and shared back-home app navigation are present; World is included in the offline shell"
     },
     "node_queue": {
       "status": "green",
-      "note": "Public light-node inbox and outbox feeds are now exposed through the docs surface for bounded assignment visibility"
+      "note": "Public light-node inbox and outbox feeds are exposed through the docs surface for bounded assignment visibility"
     },
     "node_claims": {
       "status": "green",
-      "note": "Append-only public claim feed now shows when a light node has taken bounded ownership of an assignment before reporting the result"
+      "note": "Append-only public claim feed shows when a light node has taken bounded ownership of an assignment before reporting the result"
     },
     "node_acks": {
       "status": "green",
-      "note": "Append-only public acknowledgement feed now shows how a node closed its prior claim after reporting a bounded assignment outcome"
+      "note": "Append-only public acknowledgement feed shows how a node closed its prior claim after reporting a bounded assignment outcome"
     },
     "contributors_page": {
       "status": "green",
@@ -31,11 +35,11 @@
     },
     "registration_page": {
       "status": "green",
-      "note": "Registration status page now loads publicly as the honest path for joining status and pilot-first registration posture"
+      "note": "Registration status page loads publicly as the honest path for joining status and pilot-first registration posture"
     },
     "registration_checklist": {
       "status": "green",
-      "note": "Registration pilot readiness checklist now loads publicly from the docs surface and matches the live Atlas and registration path"
+      "note": "Registration pilot readiness checklist loads publicly from the docs surface and matches the live Atlas and registration path"
     },
     "get_started_page": {
       "status": "green",
@@ -43,11 +47,11 @@
     },
     "map_page": {
       "status": "green",
-      "note": "Map page and add-pin paths load publicly"
+      "note": "Map page and consent-based add-pin paths load publicly"
     },
     "contact_page": {
       "status": "green",
-      "note": "Simple public human contact path loads publicly"
+      "note": "Simple public human contact and correction path loads publicly"
     },
     "privacy_page": {
       "status": "green",
@@ -63,7 +67,11 @@
     },
     "atlas_page": {
       "status": "green",
-      "note": "Atlas route loads publicly"
+      "note": "Atlas route loads publicly and remains the canonical repository-orientation layer"
+    },
+    "coordination_stage_b": {
+      "status": "green",
+      "note": "Synthetic consent-to-delivery breathing test is merged and validated in repo-health; no live allocation service is enabled"
     }
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>GroundMesh - Stand for Life</title>
-  <meta name="description" content="GroundMesh is a life-first public covenant and coordination seed joined to an Atlas-backed docs layer for transparent growth." />
+  <title>GroundMesh - See Clearly, Coordinate Freely</title>
+  <meta name="description" content="GroundMesh is a lightweight public coordination layer for seeing needs, capacity, evidence, participation paths, and corrections without surrendering agency." />
   <meta name="theme-color" content="#1f5c46" />
   <link rel="icon" href="./assets/gm-app-icon.svg" type="image/svg+xml" />
   <link rel="manifest" href="./manifest.webmanifest" />
@@ -248,24 +248,21 @@
         <span class="brand-mark"></span>
         <div>
           <strong>GroundMesh</strong>
-          <span>Life-first covenant and public coordination layer</span>
+          <span>See clearly. Choose freely. Coordinate.</span>
         </div>
       </div>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
       <nav class="nav-links" id="site-nav">
-        <a class="nav-link" href="#covenant">Covenant</a>
-        <a class="nav-link" href="#join">Join</a>
-        <a class="nav-link" href="#support">Support</a>
-        <a class="nav-link" href="#trust">Trust</a>
-        <a class="nav-link" href="register.html">Register</a>
-        <a class="nav-link" href="get-started/index.html">Get Started</a>
-        <a class="nav-link" href="atlas/index.html">Atlas</a>
-        <a class="nav-link" href="contribute.html">Contribute</a>
+        <a class="nav-link" href="world.html">World</a>
         <a class="nav-link" href="map.html">Map</a>
+        <a class="nav-link" href="register.html">Participate</a>
+        <a class="nav-link" href="contribute.html">Contribute</a>
+        <a class="nav-link" href="contact.html">Correct / Contact</a>
+        <a class="nav-link" href="#covenant">Covenant</a>
+        <a class="nav-link" href="atlas/index.html">Atlas</a>
         <a class="nav-link" href="compute.html">Compute</a>
-        <a class="nav-link" href="contact.html">Contact</a>
         <a class="nav-link" href="privacy.html">Privacy</a>
-        <a class="nav-link" href="landscape.html">Landscape</a>
+        <a class="nav-link" href="get-started/index.html">Builders</a>
       </nav>
     </div>
   </header>
@@ -273,63 +270,62 @@
   <main class="wrap">
     <section class="hero">
       <div class="hero-copy">
-        <div class="eyebrow">GroundMesh public seed</div>
-        <h1>Stand for life, then build the weave carefully.</h1>
+        <div class="eyebrow">GroundMesh</div>
+        <h1>See needs. Find capacity. Coordinate freely.</h1>
         <p>
-          GroundMesh is a voluntary coordination layer for people who refuse war, corruption,
-          coercion, and exploitation, and who want that refusal to become practical,
-          transparent, and connected.
+          GroundMesh is a public, voluntary coordination layer for making needs, available capacity,
+          evidence, commitments, delivery, and corrections easier to see and connect.
         </p>
         <p>
-          This front door now carries the stronger public seed energy from the newer
-          <code>groundmesh-world</code> site while staying joined to the Atlas-backed docs layer
-          that keeps growth inspectable and less likely to drift.
+          Start with <strong>World</strong> if you are simply arriving. The deeper Atlas, compute,
+          architecture, and builder surfaces remain available when you need to inspect how it works.
         </p>
         <div class="actions">
-          <a class="btn primary" href="get-started/index.html">Get Started</a>
-          <a class="btn secondary" href="#join">Stand for Life</a>
+          <a class="btn primary" href="world.html">Open World</a>
+          <a class="btn secondary" href="map.html">Explore Map</a>
+          <a class="btn secondary" href="register.html">Participate</a>
+          <a class="btn secondary" href="contribute.html">Contribute</a>
           <a class="btn secondary" href="#covenant">Read the Covenant</a>
-          <a class="btn secondary" href="atlas/index.html">Open Atlas</a>
-          <a class="btn secondary" href="https://mailgmirko-creator.github.io/groundmesh-world/">Open World Seed</a>
-          <a class="btn secondary" href="landscape.html">Scan the Landscape</a>
+          <a class="btn secondary" href="atlas/index.html">Inspect Atlas</a>
         </div>
       </div>
       <aside class="metric-grid">
-        <div class="metric"><strong>Public seed</strong><span>Human-facing front door</span></div>
-        <div class="metric"><strong>Atlas-backed</strong><span>Operational memory</span></div>
-        <div class="metric"><strong>Life-first</strong><span>Operating ethic</span></div>
-        <div class="metric"><strong>Static and safe</strong><span>Good for careful publishing</span></div>
+        <div class="metric"><strong>No account</strong><span>Read the public layer freely</span></div>
+        <div class="metric"><strong>Evidence-linked</strong><span>Sources and uncertainty stay visible</span></div>
+        <div class="metric"><strong>Consent-first</strong><span>Suggestions are not commands</span></div>
+        <div class="metric"><strong>Open source</strong><span>Inspect, question, correct, contribute</span></div>
       </aside>
     </section>
 
     <section class="surface-grid">
-      <article class="card"><h3>Get Started</h3><p>The clearest first stop for builders who want the repo, checks, and safe contribution path.</p><a href="get-started/index.html">Open Get Started</a></article>
-      <article class="card"><h3>Register</h3><p>The current public status page for joining, declared participation, and what is not open yet.</p><a href="register.html">Open Registration Status</a></article>
-      <article class="card"><h3>Atlas</h3><p>See what already exists before adding anything new.</p><a href="atlas/index.html">Open Atlas</a></article>
-      <article class="card"><h3>Contribute</h3><p>The low-friction public on-ramp for people who want to help.</p><a href="contribute.html">Open Contributors Hub</a></article>
-      <article class="card"><h3>Map</h3><p>The public orientation layer for visible relation and participation.</p><a href="map.html">Open the Map</a></article>
-      <article class="card"><h3>Compute</h3><p>Transparency page for non-sensitive metrics and public operational signals.</p><a href="compute.html">Open Compute</a></article>
-      <article class="card"><h3>Landscape</h3><p>A broader scan of local repos, live surfaces, and the newer site lineage.</p><a href="landscape.html">Open Landscape</a></article>
+      <article class="card"><h3>World</h3><p>A lightweight view of major needs, current GroundMesh actions, evidence, and the coordination loop.</p><a href="world.html">Open World</a></article>
+      <article class="card"><h3>Map</h3><p>Explore the current consent-based community map and public pin path.</p><a href="map.html">Open Map</a></article>
+      <article class="card"><h3>Participate</h3><p>See what registration means today, what is open, and what is still pilot-only.</p><a href="register.html">Registration Status</a></article>
+      <article class="card"><h3>Contribute</h3><p>Help with code, evidence, documentation, design, or practical public work.</p><a href="contribute.html">Contributors Hub</a></article>
+      <article class="card"><h3>Correct</h3><p>Question a claim, request a correction, or ask what information is public.</p><a href="contact.html">Contact / Correction</a></article>
+      <article class="card"><h3>Atlas</h3><p>Inspect what already exists before proposing another layer or feature.</p><a href="atlas/index.html">Open Atlas</a></article>
+      <article class="card"><h3>Compute</h3><p>See non-sensitive operational signals and bounded node activity.</p><a href="compute.html">Open Compute</a></article>
+      <article class="card"><h3>Builders</h3><p>Repository setup, health checks, and the guarded contribution workflow.</p><a href="get-started/index.html">Get Started</a></article>
     </section>
 
     <section class="two">
       <div class="box">
         <div class="eyebrow">Public trust</div>
-        <h2>Contact and privacy now exist as real pages.</h2>
-        <p>The project now has a simple human contact path and a plain-language privacy posture, so the public layer is more honest about what it is and what it is not.</p>
+        <h2>Read first. Verify. Correct what is wrong.</h2>
+        <p>GroundMesh keeps a public contact path, privacy posture, evidence trail, and correction route so the public layer can be questioned rather than merely believed.</p>
       </div>
       <div class="box">
-        <h3>Use these if unsure</h3>
-        <p>If you want to ask a question, request a correction, or check what is public before sharing, start there.</p>
-        <a href="contact.html">Open Contact</a><br />
+        <h3>If something is unclear</h3>
+        <p>Ask a question, request a correction, or check what is public before sharing anything sensitive.</p>
+        <a href="contact.html">Open Contact / Correction</a><br />
         <a href="privacy.html">Open Privacy</a>
       </div>
     </section>
 
     <section class="cards">
-      <article class="card"><h3>What this is</h3><p>A public covenant and coordination seed for life-first people, circles, and places. Not a party, not a cult, not a state, not a militia.</p></article>
-      <article class="card"><h3>What works right now</h3><p>The public statement, Atlas, contributors flow, map, and docs layer can already orient people without pretending the emergency network is fully operational.</p></article>
-      <article class="card"><h3>Why the merge matters</h3><p>The public narrative can invite the world in, while the operational layer keeps the project honest, inspectable, and easier to extend safely.</p></article>
+      <article class="card"><h3>What this is</h3><p>A public covenant and coordination layer for people, circles, projects, and places that want clearer evidence and voluntary cooperation. Not a party, cult, state, militia, or central planner.</p></article>
+      <article class="card"><h3>What works right now</h3><p>World, the public map, registration status, contributors flow, contact/correction, Atlas, compute transparency, and the docs layer are usable without pretending live global coordination already exists.</p></article>
+      <article class="card"><h3>How it grows</h3><p>Small guarded changes become public only after evidence, validation, review, and rollback remain understandable. Capability may increase; authority should remain bounded.</p></article>
     </section>
 
     <section id="covenant" class="two">
@@ -390,26 +386,26 @@
 
     <section class="two">
       <div class="box">
-        <div class="eyebrow">Launch guidance</div>
-        <h2>How to share this responsibly</h2>
-        <p>Tell people this is a founding public seed and an Atlas-connected front door, not yet a fully operational emergency network.</p>
+        <div class="eyebrow">Share responsibly</div>
+        <h2>Send people to World first.</h2>
+        <p>The World page is the simplest public explanation. Use Atlas, compute, architecture, and builder pages when someone wants to inspect the machinery underneath.</p>
       </div>
       <div class="box">
-        <h3>Before going wider</h3>
+        <h3>Before live coordination opens wider</h3>
         <ul class="list">
-          <li>Keep the contact path monitored and responsive</li>
+          <li>Keep the contact and correction path monitored and responsive</li>
           <li>Keep the privacy and data-minimization posture current</li>
           <li>Replace prototype forms with a real intake method</li>
           <li>Create a moderation and verification review process</li>
           <li>Keep the public <a href="checklists/Registration_Pilot_Readiness_Checklist.md">registration readiness checklist</a> honestly green before opening intake</li>
-          <li>Keep the first promise smaller than the eventual mission</li>
+          <li>Keep the first operational promise smaller than the eventual mission</li>
         </ul>
       </div>
     </section>
 
     <section class="box" style="margin-top:18px;">
-      <h3>Seed-phase note</h3>
-      <p>This version is strong enough as a public statement and directional site. It is not yet strong enough to safely process live public declarations or emergencies without a real intake, review, privacy, and moderation layer behind it.</p>
+      <h3>Current boundary</h3>
+      <p>GroundMesh can already orient, document, expose evidence, accept contribution, and show public project state. It does not yet promise live emergency response or open real-world need-to-capacity allocation. Those gates stay closed until the evidence, consent, privacy, moderation, correction, and governance layers are ready.</p>
     </section>
   </main>
 

--- a/docs/manifest.webmanifest
+++ b/docs/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "GroundMesh",
   "short_name": "GroundMesh",
-  "description": "Life-first public covenant, coordination seed, and mesh entry point.",
+  "description": "Lightweight public coordination layer for needs, capacity, evidence, and voluntary action.",
   "lang": "en",
   "dir": "ltr",
   "id": "./",
@@ -20,10 +20,16 @@
   ],
   "shortcuts": [
     {
-      "name": "Atlas",
-      "short_name": "Atlas",
-      "description": "Open the GroundMesh Atlas.",
-      "url": "./atlas/index.html"
+      "name": "World",
+      "short_name": "World",
+      "description": "Open the lightweight GroundMesh world view.",
+      "url": "./world.html"
+    },
+    {
+      "name": "Map",
+      "short_name": "Map",
+      "description": "Open the living map.",
+      "url": "./map.html"
     },
     {
       "name": "Register",
@@ -32,10 +38,10 @@
       "url": "./register.html"
     },
     {
-      "name": "Map",
-      "short_name": "Map",
-      "description": "Open the living map.",
-      "url": "./map.html"
+      "name": "Atlas",
+      "short_name": "Atlas",
+      "description": "Open the GroundMesh Atlas.",
+      "url": "./atlas/index.html"
     },
     {
       "name": "Compute",

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // docs/sw.js — prefer fresh network content, fall back to cache when offline
-const CACHE = "gm-v9";
+const CACHE = "gm-v10";
 const ASSETS = [
   "./",
   "./index.html",
@@ -24,7 +24,8 @@ const ASSETS = [
   "./map.html",
   "./privacy.html",
   "./register-pilot.html",
-  "./register.html"
+  "./register.html",
+  "./world.html"
 ];
 
 self.addEventListener("install", (e) => {

--- a/docs/world.html
+++ b/docs/world.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>GroundMesh World — Needs, Capacity, Evidence, Action</title>
+  <meta name="description" content="A lightweight public GroundMesh view of major human needs, evidence, current participation paths, and the consent-first coordination model." />
+  <meta name="theme-color" content="#1f5c46" />
+  <link rel="icon" href="./assets/gm-app-icon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="./manifest.webmanifest" />
+  <script src="./assets/pwa-init.js" defer></script>
+  <style>
+    :root {
+      --bg:#0b0f14;
+      --panel:#151c26;
+      --panel2:#1b2431;
+      --text:#eef2f7;
+      --muted:#b8c2cf;
+      --line:rgba(255,255,255,.09);
+      --accent:#95e3ae;
+      --accent2:#8bc4ff;
+      --warn:#ffd7a8;
+      --max:1080px;
+    }
+    * { box-sizing:border-box; }
+    html { scroll-behavior:smooth; }
+    body {
+      margin:0;
+      color:var(--text);
+      background:
+        radial-gradient(circle at top, rgba(139,196,255,.09), transparent 30%),
+        linear-gradient(180deg,#0a0e13,#0f141b);
+      font-family:system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif;
+      line-height:1.55;
+    }
+    a { color:inherit; }
+    .wrap { width:min(calc(100% - 30px),var(--max)); margin:0 auto; }
+    header { border-bottom:1px solid var(--line); background:rgba(10,14,19,.9); }
+    .topbar { min-height:64px; display:flex; align-items:center; justify-content:space-between; gap:16px; }
+    .brand { font-weight:800; text-decoration:none; }
+    .nav { display:flex; flex-wrap:wrap; gap:8px; }
+    .nav a { color:var(--muted); text-decoration:none; padding:8px 10px; border-radius:999px; border:1px solid var(--line); font-size:.92rem; }
+    main { padding:30px 0 54px; }
+    .hero,.card,.panel { border:1px solid var(--line); background:rgba(255,255,255,.025); border-radius:20px; }
+    .hero { padding:clamp(24px,5vw,46px); }
+    .eyebrow { color:var(--accent); font-size:.76rem; font-weight:800; letter-spacing:.18em; text-transform:uppercase; margin-bottom:12px; }
+    h1,h2,h3 { line-height:1.08; margin:0 0 14px; }
+    h1 { font-size:clamp(2.25rem,6vw,4.6rem); max-width:13ch; }
+    h2 { font-size:clamp(1.55rem,3vw,2.35rem); }
+    h3 { font-size:1.08rem; }
+    p { color:var(--muted); margin:0 0 14px; }
+    .lead { max-width:68ch; font-size:1.08rem; }
+    .actions { display:flex; flex-wrap:wrap; gap:10px; margin-top:20px; }
+    .btn { min-height:44px; display:inline-flex; align-items:center; justify-content:center; padding:0 16px; border-radius:999px; text-decoration:none; font-weight:750; border:1px solid var(--line); }
+    .btn.primary { background:var(--accent); color:#08100b; border-color:transparent; }
+    .section { margin-top:22px; }
+    .grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; }
+    .card,.panel { padding:20px; }
+    .number { display:block; font-size:clamp(2rem,5vw,3.4rem); font-weight:850; letter-spacing:-.03em; margin:4px 0 8px; }
+    .label { color:var(--text); font-weight:750; }
+    .meta { color:var(--muted); font-size:.88rem; }
+    .source { display:inline-block; margin-top:9px; color:var(--accent2); font-weight:700; }
+    .path-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:12px; }
+    .path { padding:18px; border-radius:16px; background:var(--panel); border:1px solid var(--line); }
+    .path a { color:var(--accent); font-weight:800; }
+    .flow { display:flex; flex-wrap:wrap; gap:8px; align-items:center; color:var(--muted); }
+    .step { padding:8px 11px; border-radius:999px; background:var(--panel2); border:1px solid var(--line); color:var(--text); font-weight:650; }
+    .arrow { color:var(--accent2); }
+    .note { border-left:4px solid var(--warn); padding-left:14px; color:var(--muted); }
+    .plain-list { margin:8px 0 0; padding-left:20px; color:var(--muted); }
+    .plain-list li + li { margin-top:7px; }
+    footer { padding:0 0 36px; color:var(--muted); font-size:.9rem; }
+    @media (max-width:760px) {
+      .topbar { align-items:flex-start; flex-direction:column; padding:14px 0; }
+      .grid,.path-grid { grid-template-columns:1fr; }
+      main { padding-top:18px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap topbar">
+      <a class="brand" href="index.html">GroundMesh</a>
+      <nav class="nav" aria-label="World navigation">
+        <a href="#world">World</a>
+        <a href="#use-now">Use now</a>
+        <a href="map.html">Map</a>
+        <a href="contact.html">Correct / Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <section class="hero" id="world">
+      <div class="eyebrow">GroundMesh World · public v0.1</div>
+      <h1>See needs. See capacity. Act freely.</h1>
+      <p class="lead">GroundMesh is building a public coordination layer where evidence-backed needs and available capacity can become easier to see, connect, verify, and correct — without turning the platform into a central planner or a judge of people.</p>
+      <p>No account is required to read this page. The numbers below are dated global indicators, not live local requests and not a score of the world.</p>
+      <div class="actions">
+        <a class="btn primary" href="#use-now">What can I do now?</a>
+        <a class="btn" href="map.html">Open Living Map</a>
+        <a class="btn" href="coordination/coordination-field.md">Read the model</a>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="eyebrow">A few visible gaps</div>
+      <h2>Large capability exists. Large access gaps remain.</h2>
+      <p class="lead">These indicators are deliberately few. They give the coordination problem a human scale without pretending four numbers describe the whole planet.</p>
+      <div class="grid">
+        <article class="card">
+          <span class="number">2.1B</span>
+          <div class="label">people lacked safely managed drinking water</div>
+          <p>Global estimate for 2024 from the WHO/UNICEF Joint Monitoring Programme.</p>
+          <div class="meta">Data year: 2024 · checked: 2026-08-07</div>
+          <a class="source" href="https://data.unicef.org/resources/jmp-report-2025/" rel="noopener">Source: UNICEF / WHO JMP</a>
+        </article>
+        <article class="card">
+          <span class="number">655M</span>
+          <div class="label">people lacked access to electricity</div>
+          <p>Latest reported global estimate for 2024; global access was about 92%.</p>
+          <div class="meta">Data year: 2024 · checked: 2026-08-07</div>
+          <a class="source" href="https://www.worldbank.org/en/news/press-release/2026/06/16/accelerating-universal-energy-access" rel="noopener">Source: World Bank and SDG7 partners</a>
+        </article>
+        <article class="card">
+          <span class="number">2.6B</span>
+          <div class="label">people could not afford a healthy diet</div>
+          <p>FAO's 2025 food-security reporting also estimated about 673 million people experienced hunger in 2024.</p>
+          <div class="meta">Data year: 2024 · checked: 2026-08-07</div>
+          <a class="source" href="https://www.fao.org/newsroom/detail/global-hunger-declines--but-rises-in-africa-and-western-asia--un-report/" rel="noopener">Source: FAO / SOFI 2025</a>
+        </article>
+        <article class="card">
+          <span class="number">2.8B</span>
+          <div class="label">people experience some form of housing inadequacy</div>
+          <p>UN-Habitat's broad housing estimate includes different forms and severities of inadequate housing.</p>
+          <div class="meta">Published: 2025 · checked: 2026-08-07</div>
+          <a class="source" href="https://unhabitat.org/news/19-sep-2025/putting-housing-at-the-centre-of-sustainable-development" rel="noopener">Source: UN-Habitat</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="section panel" id="use-now">
+      <div class="eyebrow">Use GroundMesh now</div>
+      <h2>Four things are real today.</h2>
+      <div class="path-grid">
+        <div class="path"><h3>Explore</h3><p>See the current consent-based community map.</p><a href="map.html">Open Map</a></div>
+        <div class="path"><h3>Participate</h3><p>Check the honest registration status and pilot boundary.</p><a href="register.html">Registration</a></div>
+        <div class="path"><h3>Build</h3><p>Help improve code, evidence, documentation, or public surfaces.</p><a href="contribute.html">Contribute</a></div>
+        <div class="path"><h3>Correct</h3><p>Question a claim, request a correction, or ask what is public.</p><a href="contact.html">Contact</a></div>
+      </div>
+    </section>
+
+    <section class="section panel">
+      <div class="eyebrow">Coordination, not control</div>
+      <h2>The loop GroundMesh is testing</h2>
+      <div class="flow" aria-label="GroundMesh coordination loop">
+        <span class="step">Need</span><span class="arrow">→</span>
+        <span class="step">Capacity</span><span class="arrow">→</span>
+        <span class="step">Possible match</span><span class="arrow">→</span>
+        <span class="step">Consent</span><span class="arrow">→</span>
+        <span class="step">Commitment</span><span class="arrow">→</span>
+        <span class="step">Delivery</span><span class="arrow">→</span>
+        <span class="step">Verification</span><span class="arrow">→</span>
+        <span class="step">Correction</span>
+      </div>
+      <p style="margin-top:16px;">A proposal is not a command. A CI suggestion is not consent. A commitment is not delivery. A number without unit, place, time window, quality threshold, provenance, and uncertainty is not yet a coordination fact.</p>
+      <div class="actions">
+        <a class="btn" href="coordination/synthetic-breathing-test.md">See the synthetic breathing test</a>
+        <a class="btn" href="atlas/index.html">Inspect Project Atlas</a>
+      </div>
+    </section>
+
+    <section class="section panel">
+      <div class="eyebrow">Current boundary</div>
+      <h2>What is not live yet</h2>
+      <ul class="plain-list">
+        <li>No open public feed of real needs and offers yet.</li>
+        <li>No autonomous resource allocation or compulsory matching.</li>
+        <li>No emergency-response promise.</li>
+        <li>No person-worth, moral, or reputation score.</li>
+        <li>No claim that these global indicators tell us what any specific locality needs.</li>
+      </ul>
+      <p class="note" style="margin-top:16px;">The next real-world coordination demonstration should use low-risk public data and remain read-only until evidence, consent, privacy, correction, and governance rules are strong enough for more.</p>
+    </section>
+  </main>
+
+  <footer class="wrap">
+    GroundMesh World v0.1 · lightweight static public surface · evidence dates remain attached to the claims they support.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed

- add `docs/world.html` as a lightweight, no-account public World surface
- show four dated evidence-backed global access indicators: drinking water, electricity, healthy-diet affordability / hunger, and housing inadequacy
- expose four real GroundMesh actions available now: Explore, Participate, Build, and Correct
- show the consent-first coordination loop and the current boundary around live matching / allocation
- make `World` the first path from the canonical homepage and simplify the homepage language for strangers rather than project insiders
- add World to PWA shortcuts and offline cache, bumping the service-worker cache to `gm-v10`
- refresh the public status snapshot
- register `PAGE-WORLD` in Project Atlas and regenerate Atlas from 35 to 36 active entries

## Why

GroundMesh has accumulated useful architecture, evidence rules, validators, and public pages, but the canonical front door still spoke too much in internal project language. This batch creates the smallest public lens that a person can open on an ordinary phone, understand without an account, and use immediately without learning Atlas, CI infrastructure, or repository history first.

The intended product split is now clearer:

- **World** = public human-facing lens
- **Atlas** = project/repository orientation memory
- **Map** = consent-based place/presence view
- **Compute** = operational transparency
- **Builders** = contribution and implementation path

## Public facts

The World indicators are intentionally sparse and dated rather than presented as a live dashboard or universal score. They were re-checked on 2026-08-07 against:

- WHO/UNICEF JMP: 2.1B people lacked safely managed drinking water in 2024
- World Bank / SDG7 partners: 655M people lacked electricity access in 2024
- FAO / SOFI 2025: 2.6B people could not afford a healthy diet in 2024; about 673M experienced hunger
- UN-Habitat: 2.8B people experience some form of housing inadequacy

Each card links directly to its source and keeps its data year / checked date visible.

## Guardrails preserved

- no world score or composite moral index
- no person score or reputation caste
- no live public feed of needs/offers yet
- no autonomous matching or resource allocation
- no emergency-response promise
- no account required to read
- no analytics or heavyweight framework added
- source dates and limitations remain visible
- correction/contact remains first-class

## Validation before PR

- branch starts directly from merged `main` after PR #49
- final diff is limited to 7 intended files
- Atlas change is limited to counters plus the `PAGE-WORLD` row
- registry increases from 35 to 36 active entries
- PWA shell explicitly caches `world.html`
- homepage keeps deeper covenant, trust, registration, Atlas, and builder routes while moving them behind a simpler first screen

## Non-goals

This PR does not create the real-world coordination database, public need/offer intake, real matching service, Behavior Atlas public alpha, emergency network, or global ranking system. It creates the stable public place those future guarded capabilities can grow into.
