### PR TITLE
fix(release): make SHA-256 generation runner-portable

### DIFF
--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -7,7 +7,19 @@ $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
 $zip   = Join-Path $rels "site-$stamp.zip"
 if (Test-Path $zip) { Remove-Item $zip -Force }
 Compress-Archive -Path (Join-Path $src "*") -DestinationPath $zip
-$hash = (Get-FileHash $zip -Algorithm SHA256).Hash
+
+# Use .NET directly instead of Get-FileHash so release creation works in both
+# Windows PowerShell and pwsh environments, including GitHub-hosted runners.
+$sha256 = [System.Security.Cryptography.SHA256]::Create()
+$stream = [System.IO.File]::OpenRead($zip)
+try {
+  $hashBytes = $sha256.ComputeHash($stream)
+  $hash = -join ($hashBytes | ForEach-Object { $_.ToString("X2") })
+} finally {
+  $stream.Dispose()
+  $sha256.Dispose()
+}
+
 $man  = Join-Path $rels "site-$stamp.sha256.txt"
 ("$([IO.Path]::GetFileName($zip))  SHA256=$hash") | Out-File -FilePath $man -Encoding utf8
 Write-Host "Release created: $zip"


### PR DESCRIPTION
## What changed

- replace `Get-FileHash` in `scripts/release.ps1` with direct .NET `SHA256` hashing
- preserve the existing ZIP naming and `SHA256=<hash>` manifest format
- dispose the file stream and hash object explicitly

## Why

The post-merge `Release & IPFS` workflow is currently failing before IPFS publication. On the current GitHub-hosted Windows runner, the nested release invocation reports:

`Get-FileHash : The term 'Get-FileHash' is not recognized`

That makes the resilient release/IPFS lane red even though GitHub Pages deploys successfully.

Using `System.Security.Cryptography.SHA256` removes dependency on that cmdlet while remaining compatible with Windows PowerShell and pwsh.

## Scope

This changes only the release archive hash implementation. It does not change Pages, release contents, IPFS credentials, Web3.Storage behavior, or GroundMesh public semantics.

## Validation plan

- normal PR CI must remain green
- after merge, the `Release & IPFS` push workflow is the authoritative end-to-end test: release ZIP creation must pass and the workflow must proceed to the IPFS publication step
