### PR TITLE
ci(release): make Storacha IPFS an optional modern mirror

### DIFF
--- a/.github/workflows/release-ipfs.yml
+++ b/.github/workflows/release-ipfs.yml
@@ -1,4 +1,4 @@
-name: Release & IPFS
+name: Release & Optional IPFS Mirror
 
 on:
   workflow_dispatch:
@@ -14,9 +14,10 @@ jobs:
   build-publish:
     runs-on: windows-latest
     permissions:
-      contents: write
+      contents: read
     env:
-      W3S_TOKEN: ${{ secrets.W3S_TOKEN }}
+      STORACHA_PRINCIPAL: ${{ secrets.STORACHA_PRINCIPAL }}
+      STORACHA_PROOF: ${{ secrets.STORACHA_PROOF }}
 
     steps:
       - uses: actions/checkout@v4
@@ -37,10 +38,35 @@ jobs:
           cd apps\local-cli
           .\.venv\Scripts\python .\main.py --task release
 
-      - name: Publish to IPFS (Web3.Storage)
-        if: ${{ env.W3S_TOKEN != '' }}
+      - name: Preserve release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: groundmesh-release-${{ github.sha }}
+          path: releases/*
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish docs mirror to Storacha / IPFS
+        id: storacha
+        if: ${{ env.STORACHA_PRINCIPAL != '' && env.STORACHA_PROOF != '' }}
+        uses: storacha/add-to-web3@v4
+        with:
+          path_to_add: docs
+          secret_key: ${{ env.STORACHA_PRINCIPAL }}
+          proof: ${{ env.STORACHA_PROOF }}
+
+      - name: Report IPFS mirror
+        if: ${{ steps.storacha.outcome == 'success' }}
         shell: pwsh
-        env:
-          W3S_TOKEN: ${{ env.W3S_TOKEN }}
         run: |
-          powershell -NoProfile -ExecutionPolicy Bypass -File scripts\ipfs_publish.ps1
+          "### GroundMesh IPFS mirror" >> $env:GITHUB_STEP_SUMMARY
+          "CID: `${{ steps.storacha.outputs.cid }}`" >> $env:GITHUB_STEP_SUMMARY
+          "Gateway: ${{ steps.storacha.outputs.url }}" >> $env:GITHUB_STEP_SUMMARY
+
+      - name: Note IPFS mirror is not configured
+        if: ${{ env.STORACHA_PRINCIPAL == '' || env.STORACHA_PROOF == '' }}
+        shell: pwsh
+        run: |
+          Write-Warning "Storacha/IPFS mirror is not configured. The release artifact was preserved and GitHub Pages remains the canonical public deployment. Configure STORACHA_PRINCIPAL and STORACHA_PROOF to enable the optional mirror."
+          "### GroundMesh IPFS mirror" >> $env:GITHUB_STEP_SUMMARY
+          "Not configured for this run. GitHub Pages remains canonical." >> $env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What changed

- rename the workflow to `Release & Optional IPFS Mirror`
- preserve every generated ZIP + SHA-256 manifest as a 30-day GitHub Actions artifact
- replace the legacy `W3S_TOKEN` / `w3 up` console-parser path with the maintained `storacha/add-to-web3@v4` action
- use current delegated CI credentials: `STORACHA_PRINCIPAL` + `STORACHA_PROOF`
- publish the returned CID and gateway URL directly into the workflow summary when the mirror is configured
- when the two Storacha secrets are absent, emit an explicit warning and keep the workflow successful because the release artifact and canonical GitHub Pages deployment remain intact
- reduce workflow permissions from `contents: write` to `contents: read`

## Why

The earlier release repair proved that GroundMesh can build and hash its release archive again. The next failure was isolated to the old Web3.Storage mirror path: the legacy script depends on `W3S_TOKEN`, an implicit `w3` CLI, and parsing human-readable console output for a `bafy...` string.

Storacha's current CI contract uses a delegated signing key and proof and exposes the root CID as an action output. This change stops patching the obsolete parser and makes the mirror an honest optional resilience layer rather than a dependency of the canonical public deployment.

## Operational posture

- GitHub Pages remains canonical.
- Release archive creation is independent of IPFS.
- IPFS/Storacha is an optional mirror.
- Missing mirror credentials are visible as a workflow warning, not disguised as a successful mirror.
- Once `STORACHA_PRINCIPAL` and `STORACHA_PROOF` are configured, the same workflow automatically attempts the mirror and reports its CID.

## Current upstream reference

Storacha's maintained CI documentation and `storacha/add-to-web3` action require a CI principal/signing key plus a delegated proof; the action publishes `cid` and `url` outputs directly.

## Scope

One workflow file only. No public-site semantics, GroundMesh coordination rules, Pages deployment, user data, or allocation behavior changes.