### PR TITLE
docs(status): expose release artifact and IPFS mirror state

### DIFF
--- a/docs/data/status.json
+++ b/docs/data/status.json
@@ -1,9 +1,17 @@
 {
-  "updated_utc": "2026-08-07T14:20:00Z",
+  "updated_utc": "2026-08-07T14:45:00Z",
   "components": {
     "deployment_source": {
       "status": "green",
       "note": "GitHub Pages serves the docs-based site through the GitHub Actions deployment path"
+    },
+    "release_artifact": {
+      "status": "green",
+      "note": "Qualifying main-branch changes build a ZIP plus SHA-256 manifest and preserve them as a 30-day GitHub Actions artifact"
+    },
+    "ipfs_mirror": {
+      "status": "yellow",
+      "note": "Optional Storacha/IPFS mirror uses the current delegated-key workflow but is not enabled until STORACHA_PRINCIPAL and STORACHA_PROOF are configured; GitHub Pages remains canonical"
     },
     "home_page": {
       "status": "green",


### PR DESCRIPTION
## What changed

- refresh the public status timestamp
- add `release_artifact: green` for the now-working ZIP + SHA-256 + 30-day Actions artifact lane
- add `ipfs_mirror: yellow` to state plainly that the modern Storacha mirror is prepared but not enabled until delegated CI credentials are configured
- keep GitHub Pages identified as canonical

## Why

The operational state changed during the public World rollout and release-lane repair. GroundMesh should expose that truth in its own public status data rather than leaving it only in GitHub Actions and Issue #53.

## Scope

One already-registered status JSON file only. No new architecture, public claims, user data, or runtime behavior.